### PR TITLE
Update with history fixes for CQL, show results

### DIFF
--- a/src/services/cql/crc/DataElements.cql
+++ b/src/services/cql/crc/DataElements.cql
@@ -518,15 +518,45 @@ define PrecancerousPolypsInAnyPreviousColonoscopy:
 // Colorectal screening modalities
 //------------------------------------------------------------------------------
 
-//TODO Use single retrieve for all completed Diagnostic reports in lookback and then filter by modality.
-define ColorectalCancerScreeningDiagnosticReports:
-  Common.CompletedDiagnosticReport([DiagnosticReport: "Colorectal Screening Modalities"])  
+define AllCompletedDiagnosticReports:
+  Common.CompletedDiagnosticReport([DiagnosticReport])
 
-define AllCompletedDiagnosticReport:
-  Common.CompletedDiagnosticReport([DiagnosticReport])    
+define AllCompletedDiagnosticReportsInLookback:
+  Common.LookBack(AllCompletedDiagnosticReports, ScreeningHistoryLookback)
+
+define ColorectalCancerScreeningDiagnosticReports:
+  if ScreeningHistoryLookback is not null
+    then
+      distinct(
+        AllCompletedDiagnosticReportsInLookback R
+          where R.code in "Colorectal Screening Modalities"
+      )
+  else
+      distinct(
+        AllCompletedDiagnosticReports R
+          where R.code in "Colorectal Screening Modalities"
+      )
+
+define AllVerifiedObservations:
+  C3F.Verified([Observation])
+
+define AllVerifiedObservationsInLookback:
+  C3F.ObservationLookBack(AllVerifiedObservations, ScreeningHistoryLookback)
 
 define ColorectalCancerScreeningObservations:
-  FOBTObservations union StoolDNAFITObservations union ColonoscopyObservations union CTColonographyObservations union FlexSigObservations
+  if ScreeningHistoryLookback is not null
+    then
+      distinct(
+        AllVerifiedObservationsInLookback O
+          where O.code in "Colorectal Screening Modalities"
+          or O.code ~ "Follow-up Plan"
+      )
+  else
+      distinct(
+        AllVerifiedObservations O
+          where O.code in "Colorectal Screening Modalities"
+          or O.code ~ "Follow-up Plan"
+      )
 
 //FOBT (includes FIT and gFOBT)
 define "de-FOBT":
@@ -538,10 +568,12 @@ define FOBTDiagnosticReportsWithResults:
     exists CRCSMCommon.CollateConclusionCodes(D, FOBTObservations)
 
 define FOBTDiagnosticReports:
-  CRCSMCommon.CompletedDiagnosticReportsByLookback("Fecal Occult Blood Test", ScreeningHistoryLookback)
+  ColorectalCancerScreeningDiagnosticReports R
+   where R.code in "Fecal Occult Blood Test"
 
 define FOBTObservations:
-  CRCSMCommon.VerifiedObservations("Fecal Occult Blood Test", ScreeningHistoryLookback)
+  ColorectalCancerScreeningObservations O
+    where O.code in "Fecal Occult Blood Test"
 
 // Stool DNA-FIT
 define "de-stoolDNAFIT":
@@ -553,10 +585,12 @@ define StoolDNAFITDiagnosticReportsWithResults:
       exists CRCSMCommon.CollateConclusionCodes(D, StoolDNAFITObservations)
 
 define StoolDNAFITDiagnosticReports:
-  CRCSMCommon.CompletedDiagnosticReportsByLookback("Stool DNA-FIT", ScreeningHistoryLookback)
+  ColorectalCancerScreeningDiagnosticReports R
+   where R.code in "Stool DNA-FIT"
 
 define StoolDNAFITObservations:
-  CRCSMCommon.VerifiedObservations("Stool DNA-FIT", ScreeningHistoryLookback)
+  ColorectalCancerScreeningObservations O
+    where O.code in "Stool DNA-FIT"
 
 // Colonoscopy
 define "de-Colonoscopy": 
@@ -569,12 +603,13 @@ define ColonoscopyDiagnosticReportsWithResults:
       exists CRCSMCommon.ValueQuantityFromObservation(D,FollowUpObservations)
 
 define ColonoscopyDiagnosticReports:
-  CRCSMCommon.CompletedDiagnosticReportsByLookback("Colonoscopy Study", ScreeningHistoryLookback)
+  ColorectalCancerScreeningDiagnosticReports R
+    where R.code in "Colonoscopy Study"
 
 define ColonoscopyObservations:
-  CRCSMCommon.VerifiedObservations("Colonoscopy Study", ScreeningHistoryLookback)
-  union
-  CRCSMCommon.VerifiedObservations("Colonoscopy Study Observation", ScreeningHistoryLookback)
+  ColorectalCancerScreeningObservations O
+    where O.code in "Colonoscopy Study"
+      or O.code ~ "Colonoscopy Study Observation"
 
 // CT Colonography
 define "de-CTColonography":
@@ -586,10 +621,12 @@ define CTColonographyDiagnosticReportsWithResults:
       exists CRCSMCommon.CollateConclusionCodes(D, CTColonographyObservations)
 
 define CTColonographyDiagnosticReports:
-  CRCSMCommon.CompletedDiagnosticReportsByLookback("CT Colonography Study", ScreeningHistoryLookback)
+  ColorectalCancerScreeningDiagnosticReports R
+   where R.code in "CT Colonography Study"
 
 define CTColonographyObservations:
-  CRCSMCommon.VerifiedObservations("CT Colonography Study", ScreeningHistoryLookback)
+  ColorectalCancerScreeningObservations O
+    where O.code in "CT Colonography Study"
 
 // Flex Sig
 define "de-FlexSig":
@@ -602,16 +639,18 @@ define FlexSigDiagnosticReportsWithResults:
       exists CRCSMCommon.ValueQuantityFromObservation(D,FollowUpObservations)
 
 define FlexSigDiagnosticReports:
-  CRCSMCommon.CompletedDiagnosticReportsByLookback("Flexible Sigmoidoscopy Study", ScreeningHistoryLookback)
+  ColorectalCancerScreeningDiagnosticReports R
+   where R.code in "Flexible Sigmoidoscopy Study"
 
 define FlexSigObservations:
-  CRCSMCommon.VerifiedObservations("Flexible Sigmoidoscopy Study", ScreeningHistoryLookback)
-  union
-  CRCSMCommon.VerifiedObservations("Flexible Sigmoidoscopy Study Observation", ScreeningHistoryLookback)
+ColorectalCancerScreeningObservations O
+    where O.code in "Flexible Sigmoidoscopy Study"
+      or O.code ~ "Flexible Sigmoidoscopy Study Observation"
 
 //Follow Up
 define FollowUpObservations:
-  CRCSMCommon.VerifiedObservations("Follow-up Plan", ScreeningHistoryLookback)
+    ColorectalCancerScreeningObservations O
+    where O.code ~ "Follow-up Plan"
 
 //------------------------------------------------------------------------------
 // Most recent colorectal screening/surveillance test

--- a/src/services/cql/crc/DataElements.json
+++ b/src/services/cql/crc/DataElements.json
@@ -9,7 +9,7 @@
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "4213",
+            "r" : "4400",
             "s" : [ {
                "value" : [ "/*  \n  Author: CMS Alliance to Modernize Healthcare, operated by THE MITRE Corporation.\n\n  (C) 2025 The MITRE Corporation. All Rights Reserved. \n  Approved for Public Release: 24-2711. \n  Distribution Unlimited.\n\n  Unless otherwise noted, this work is available under an Apache 2.0 license. \n  It was produced by the MITRE Corporation for the Division of Cancer Prevention \n  and Control, Centers for Disease Control and Prevention in accordance with the \n  Statement of Work, contract number 75FCMC18D0047, task order number 75D30123F17931.\n*/\n\n","library DataElements version '1.0.0'" ]
             } ]
@@ -28069,10 +28069,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3225",
+               "localId" : "3446",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3226",
+                  "localId" : "3447",
                   "name" : "{http://hl7.org/fhir}Condition",
                   "type" : "NamedTypeSpecifier"
                }
@@ -28133,8 +28133,620 @@
                } ]
             }
          }, {
+            "localId" : "3086",
+            "locator" : "521:1-522:54",
+            "name" : "AllCompletedDiagnosticReports",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3086",
+                  "s" : [ {
+                     "value" : [ "//TODO consider whether lookback of 10 years is appropriate\n//TODO generalize to include history of precancerous polyps from other modalities (CT colonography and flex sig)\n\n//------------------------------------------------------------------------------\n// Colorectal screening modalities\n//------------------------------------------------------------------------------\n\n","define ","AllCompletedDiagnosticReports",":\n  " ]
+                  }, {
+                     "r" : "3091",
+                     "s" : [ {
+                        "r" : "3087",
+                        "s" : [ {
+                           "value" : [ "Common" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "3091",
+                        "s" : [ {
+                           "value" : [ "CompletedDiagnosticReport","(" ]
+                        }, {
+                           "r" : "3088",
+                           "s" : [ {
+                              "value" : [ "[","DiagnosticReport","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3450",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3451",
+                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3091",
+               "locator" : "522:3-522:54",
+               "name" : "CompletedDiagnosticReport",
+               "libraryName" : "Common",
+               "type" : "FunctionRef",
+               "resultTypeSpecifier" : {
+                  "localId" : "3096",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3097",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "3092",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3093",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "operand" : [ {
+                  "localId" : "3088",
+                  "locator" : "522:36-522:53",
+                  "dataType" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "templateId" : "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                  "type" : "Retrieve",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3089",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3090",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               } ]
+            }
+         }, {
+            "localId" : "3083",
+            "locator" : "524:1-525:74",
+            "name" : "AllCompletedDiagnosticReportsInLookback",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3083",
+                  "s" : [ {
+                     "value" : [ "","define ","AllCompletedDiagnosticReportsInLookback",":\n  " ]
+                  }, {
+                     "r" : "3104",
+                     "s" : [ {
+                        "r" : "3084",
+                        "s" : [ {
+                           "value" : [ "Common" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "3104",
+                        "s" : [ {
+                           "value" : [ "LookBack","(" ]
+                        }, {
+                           "r" : "3100",
+                           "s" : [ {
+                              "value" : [ "AllCompletedDiagnosticReports" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "3103",
+                           "s" : [ {
+                              "value" : [ "ScreeningHistoryLookback" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3452",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3453",
+                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3104",
+               "locator" : "525:3-525:74",
+               "name" : "LookBack",
+               "libraryName" : "Common",
+               "type" : "FunctionRef",
+               "resultTypeSpecifier" : {
+                  "localId" : "3110",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3111",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "3105",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3106",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "3107",
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "3100",
+                  "locator" : "525:19-525:47",
+                  "name" : "AllCompletedDiagnosticReports",
+                  "type" : "ExpressionRef",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3101",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3102",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               }, {
+                  "localId" : "3103",
+                  "locator" : "525:50-525:73",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "name" : "ScreeningHistoryLookback",
+                  "type" : "ParameterRef"
+               } ]
+            }
+         }, {
+            "localId" : "3073",
+            "locator" : "527:1-538:7",
+            "name" : "ColorectalCancerScreeningDiagnosticReports",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3073",
+                  "s" : [ {
+                     "value" : [ "","define ","ColorectalCancerScreeningDiagnosticReports",":\n  " ]
+                  }, {
+                     "r" : "3074",
+                     "s" : [ {
+                        "value" : [ "if " ]
+                     }, {
+                        "r" : "3078",
+                        "s" : [ {
+                           "r" : "3075",
+                           "s" : [ {
+                              "value" : [ "ScreeningHistoryLookback" ]
+                           } ]
+                        }, {
+                           "value" : [ " is not null" ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    then\n      " ]
+                     }, {
+                        "r" : "3080",
+                        "s" : [ {
+                           "value" : [ "distinct" ]
+                        }, {
+                           "r" : "3126",
+                           "s" : [ {
+                              "value" : [ "(\n        " ]
+                           }, {
+                              "r" : "3126",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "r" : "3081",
+                                    "s" : [ {
+                                       "r" : "3114",
+                                       "s" : [ {
+                                          "s" : [ {
+                                             "value" : [ "AllCompletedDiagnosticReportsInLookback" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " ","R" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ "\n          " ]
+                              }, {
+                                 "r" : "3122",
+                                 "s" : [ {
+                                    "value" : [ "where " ]
+                                 }, {
+                                    "r" : "3122",
+                                    "s" : [ {
+                                       "r" : "3120",
+                                       "s" : [ {
+                                          "r" : "3119",
+                                          "s" : [ {
+                                             "value" : [ "R" ]
+                                          } ]
+                                       }, {
+                                          "value" : [ "." ]
+                                       }, {
+                                          "r" : "3120",
+                                          "s" : [ {
+                                             "value" : [ "code" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " in " ]
+                                    }, {
+                                       "r" : "3121",
+                                       "s" : [ {
+                                          "value" : [ "\"Colorectal Screening Modalities\"" ]
+                                       } ]
+                                    } ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      )" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n  else\n      " ]
+                     }, {
+                        "r" : "3135",
+                        "s" : [ {
+                           "value" : [ "distinct" ]
+                        }, {
+                           "r" : "3149",
+                           "s" : [ {
+                              "value" : [ "(\n        " ]
+                           }, {
+                              "r" : "3149",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "r" : "3136",
+                                    "s" : [ {
+                                       "r" : "3137",
+                                       "s" : [ {
+                                          "s" : [ {
+                                             "value" : [ "AllCompletedDiagnosticReports" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " ","R" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ "\n          " ]
+                              }, {
+                                 "r" : "3145",
+                                 "s" : [ {
+                                    "value" : [ "where " ]
+                                 }, {
+                                    "r" : "3145",
+                                    "s" : [ {
+                                       "r" : "3143",
+                                       "s" : [ {
+                                          "r" : "3142",
+                                          "s" : [ {
+                                             "value" : [ "R" ]
+                                          } ]
+                                       }, {
+                                          "value" : [ "." ]
+                                       }, {
+                                          "r" : "3143",
+                                          "s" : [ {
+                                             "value" : [ "code" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " in " ]
+                                    }, {
+                                       "r" : "3144",
+                                       "s" : [ {
+                                          "value" : [ "\"Colorectal Screening Modalities\"" ]
+                                       } ]
+                                    } ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      )" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3454",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3455",
+                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3074",
+               "locator" : "528:3-538:7",
+               "type" : "If",
+               "resultTypeSpecifier" : {
+                  "localId" : "3158",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3159",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "condition" : {
+                  "localId" : "3078",
+                  "locator" : "528:6-528:41",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Not",
+                  "signature" : [ {
+                     "localId" : "3079",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "operand" : {
+                     "localId" : "3076",
+                     "locator" : "528:6-528:41",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "IsNull",
+                     "signature" : [ {
+                        "localId" : "3077",
+                        "name" : "{urn:hl7-org:elm-types:r1}Any",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : {
+                        "localId" : "3075",
+                        "locator" : "528:6-528:29",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "name" : "ScreeningHistoryLookback",
+                        "type" : "ParameterRef"
+                     }
+                  }
+               },
+               "then" : {
+                  "localId" : "3080",
+                  "locator" : "530:7-533:7",
+                  "type" : "Distinct",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3133",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3134",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ {
+                     "localId" : "3131",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3132",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "3126",
+                     "locator" : "530:15-533:7",
+                     "type" : "Query",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3129",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3130",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "source" : [ {
+                        "localId" : "3081",
+                        "locator" : "531:9-531:49",
+                        "alias" : "R",
+                        "resultTypeSpecifier" : {
+                           "localId" : "3117",
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "localId" : "3118",
+                              "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        },
+                        "expression" : {
+                           "localId" : "3114",
+                           "locator" : "531:9-531:47",
+                           "name" : "AllCompletedDiagnosticReportsInLookback",
+                           "type" : "ExpressionRef",
+                           "resultTypeSpecifier" : {
+                              "localId" : "3115",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "3116",
+                                 "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     } ],
+                     "let" : [ ],
+                     "relationship" : [ ],
+                     "where" : {
+                        "localId" : "3122",
+                        "locator" : "532:11-532:59",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "InValueSet",
+                        "signature" : [ {
+                           "localId" : "3125",
+                           "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "code" : {
+                           "localId" : "3123",
+                           "name" : "ToConcept",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
+                           "signature" : [ {
+                              "localId" : "3124",
+                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "operand" : [ {
+                              "localId" : "3120",
+                              "locator" : "532:17-532:22",
+                              "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                              "path" : "code",
+                              "scope" : "R",
+                              "type" : "Property"
+                           } ]
+                        },
+                        "valueset" : {
+                           "localId" : "3121",
+                           "locator" : "532:27-532:59",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                           "name" : "Colorectal Screening Modalities",
+                           "preserve" : true
+                        }
+                     }
+                  }
+               },
+               "else" : {
+                  "localId" : "3135",
+                  "locator" : "535:7-538:7",
+                  "type" : "Distinct",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3156",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3157",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ {
+                     "localId" : "3154",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3155",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "3149",
+                     "locator" : "535:15-538:7",
+                     "type" : "Query",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3152",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3153",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "source" : [ {
+                        "localId" : "3136",
+                        "locator" : "536:9-536:39",
+                        "alias" : "R",
+                        "resultTypeSpecifier" : {
+                           "localId" : "3140",
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "localId" : "3141",
+                              "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        },
+                        "expression" : {
+                           "localId" : "3137",
+                           "locator" : "536:9-536:37",
+                           "name" : "AllCompletedDiagnosticReports",
+                           "type" : "ExpressionRef",
+                           "resultTypeSpecifier" : {
+                              "localId" : "3138",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "3139",
+                                 "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     } ],
+                     "let" : [ ],
+                     "relationship" : [ ],
+                     "where" : {
+                        "localId" : "3145",
+                        "locator" : "537:11-537:59",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "InValueSet",
+                        "signature" : [ {
+                           "localId" : "3148",
+                           "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "code" : {
+                           "localId" : "3146",
+                           "name" : "ToConcept",
+                           "libraryName" : "FHIRHelpers",
+                           "type" : "FunctionRef",
+                           "signature" : [ {
+                              "localId" : "3147",
+                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "operand" : [ {
+                              "localId" : "3143",
+                              "locator" : "537:17-537:22",
+                              "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                              "path" : "code",
+                              "scope" : "R",
+                              "type" : "Property"
+                           } ]
+                        },
+                        "valueset" : {
+                           "localId" : "3144",
+                           "locator" : "537:27-537:59",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                           "name" : "Colorectal Screening Modalities",
+                           "preserve" : true
+                        }
+                     }
+                  }
+               }
+            }
+         }, {
             "localId" : "3070",
-            "locator" : "571:1-572:97",
+            "locator" : "605:1-607:39",
             "name" : "ColonoscopyDiagnosticReports",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -28145,27 +28757,273 @@
                   "s" : [ {
                      "value" : [ "","define ","ColonoscopyDiagnosticReports",":\n  " ]
                   }, {
-                     "r" : "3074",
+                     "r" : "3174",
                      "s" : [ {
-                        "r" : "3071",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3071",
+                           "s" : [ {
+                              "r" : "3162",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningDiagnosticReports" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","R" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "3170",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "3170",
+                           "s" : [ {
+                              "r" : "3168",
+                              "s" : [ {
+                                 "r" : "3167",
+                                 "s" : [ {
+                                    "value" : [ "R" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3168",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3169",
+                              "s" : [ {
+                                 "value" : [ "\"Colonoscopy Study\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3638",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3639",
+                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3174",
+               "locator" : "606:3-607:39",
+               "type" : "Query",
+               "resultTypeSpecifier" : {
+                  "localId" : "3175",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3176",
+                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "source" : [ {
+                  "localId" : "3071",
+                  "locator" : "606:3-606:46",
+                  "alias" : "R",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3165",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3166",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3162",
+                     "locator" : "606:3-606:44",
+                     "name" : "ColorectalCancerScreeningDiagnosticReports",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3163",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3164",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               } ],
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3170",
+                  "locator" : "607:5-607:39",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3173",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3171",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3172",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3168",
+                        "locator" : "607:11-607:16",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "R",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3169",
+                     "locator" : "607:21-607:39",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Colonoscopy Study",
+                     "preserve" : true
+                  }
+               }
+            }
+         }, {
+            "localId" : "3205",
+            "locator" : "540:1-541:29",
+            "name" : "AllVerifiedObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3205",
+                  "s" : [ {
+                     "value" : [ "","define ","AllVerifiedObservations",":\n  " ]
+                  }, {
+                     "r" : "3210",
+                     "s" : [ {
+                        "r" : "3206",
+                        "s" : [ {
+                           "value" : [ "C3F" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "3074",
+                        "r" : "3210",
                         "s" : [ {
-                           "value" : [ "CompletedDiagnosticReportsByLookback","(" ]
+                           "value" : [ "Verified","(" ]
                         }, {
-                           "r" : "3072",
+                           "r" : "3207",
                            "s" : [ {
-                              "value" : [ "\"Colonoscopy Study\"" ]
+                              "value" : [ "[","Observation","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3456",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3457",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3210",
+               "locator" : "541:3-541:29",
+               "name" : "Verified",
+               "libraryName" : "C3F",
+               "type" : "FunctionRef",
+               "resultTypeSpecifier" : {
+                  "localId" : "3215",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3216",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "3211",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3212",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "operand" : [ {
+                  "localId" : "3207",
+                  "locator" : "541:16-541:28",
+                  "dataType" : "{http://hl7.org/fhir}Observation",
+                  "templateId" : "http://hl7.org/fhir/StructureDefinition/Observation",
+                  "type" : "Retrieve",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3208",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3209",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               } ]
+            }
+         }, {
+            "localId" : "3202",
+            "locator" : "543:1-544:76",
+            "name" : "AllVerifiedObservationsInLookback",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3202",
+                  "s" : [ {
+                     "value" : [ "","define ","AllVerifiedObservationsInLookback",":\n  " ]
+                  }, {
+                     "r" : "3223",
+                     "s" : [ {
+                        "r" : "3203",
+                        "s" : [ {
+                           "value" : [ "C3F" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "3223",
+                        "s" : [ {
+                           "value" : [ "ObservationLookBack","(" ]
+                        }, {
+                           "r" : "3219",
+                           "s" : [ {
+                              "value" : [ "AllVerifiedObservations" ]
                            } ]
                         }, {
                            "value" : [ ", " ]
                         }, {
-                           "r" : "3073",
+                           "r" : "3222",
                            "s" : [ {
                               "value" : [ "ScreeningHistoryLookback" ]
                            } ]
@@ -28177,125 +29035,756 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3517",
+               "localId" : "3458",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3518",
-                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                  "localId" : "3459",
+                  "name" : "{http://hl7.org/fhir}Observation",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3074",
-               "locator" : "572:3-572:97",
-               "name" : "CompletedDiagnosticReportsByLookback",
-               "libraryName" : "CRCSMCommon",
+               "localId" : "3223",
+               "locator" : "544:3-544:76",
+               "name" : "ObservationLookBack",
+               "libraryName" : "C3F",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "3079",
+                  "localId" : "3229",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3080",
-                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                     "localId" : "3230",
+                     "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "signature" : [ {
-                  "localId" : "3075",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
+                  "localId" : "3224",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3225",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "localId" : "3076",
+                  "localId" : "3226",
                   "name" : "{urn:hl7-org:elm-types:r1}Quantity",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3072",
-                  "locator" : "572:52-572:70",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Colonoscopy Study",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
+                  "localId" : "3219",
+                  "locator" : "544:27-544:49",
+                  "name" : "AllVerifiedObservations",
+                  "type" : "ExpressionRef",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3220",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3221",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
                }, {
-                  "localId" : "3073",
-                  "locator" : "572:73-572:96",
+                  "localId" : "3222",
+                  "locator" : "544:52-544:75",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
                   "name" : "ScreeningHistoryLookback",
                   "type" : "ParameterRef"
                } ]
             }
          }, {
-            "localId" : "3093",
-            "locator" : "574:1-577:93",
+            "localId" : "3192",
+            "locator" : "546:1-559:7",
+            "name" : "ColorectalCancerScreeningObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3192",
+                  "s" : [ {
+                     "value" : [ "","define ","ColorectalCancerScreeningObservations",":\n  " ]
+                  }, {
+                     "r" : "3193",
+                     "s" : [ {
+                        "value" : [ "if " ]
+                     }, {
+                        "r" : "3197",
+                        "s" : [ {
+                           "r" : "3194",
+                           "s" : [ {
+                              "value" : [ "ScreeningHistoryLookback" ]
+                           } ]
+                        }, {
+                           "value" : [ " is not null" ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    then\n      " ]
+                     }, {
+                        "r" : "3199",
+                        "s" : [ {
+                           "value" : [ "distinct" ]
+                        }, {
+                           "r" : "3259",
+                           "s" : [ {
+                              "value" : [ "(\n        " ]
+                           }, {
+                              "r" : "3259",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "r" : "3200",
+                                    "s" : [ {
+                                       "r" : "3233",
+                                       "s" : [ {
+                                          "s" : [ {
+                                             "value" : [ "AllVerifiedObservationsInLookback" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " ","O" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ "\n          " ]
+                              }, {
+                                 "r" : "3238",
+                                 "s" : [ {
+                                    "value" : [ "where " ]
+                                 }, {
+                                    "r" : "3238",
+                                    "s" : [ {
+                                       "r" : "3242",
+                                       "s" : [ {
+                                          "r" : "3240",
+                                          "s" : [ {
+                                             "r" : "3239",
+                                             "s" : [ {
+                                                "value" : [ "O" ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "." ]
+                                          }, {
+                                             "r" : "3240",
+                                             "s" : [ {
+                                                "value" : [ "code" ]
+                                             } ]
+                                          } ]
+                                       }, {
+                                          "value" : [ " in " ]
+                                       }, {
+                                          "r" : "3241",
+                                          "s" : [ {
+                                             "value" : [ "\"Colorectal Screening Modalities\"" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ "\n          or " ]
+                                    }, {
+                                       "r" : "3246",
+                                       "s" : [ {
+                                          "r" : "3248",
+                                          "s" : [ {
+                                             "r" : "3247",
+                                             "s" : [ {
+                                                "value" : [ "O" ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "." ]
+                                          }, {
+                                             "r" : "3248",
+                                             "s" : [ {
+                                                "value" : [ "code" ]
+                                             } ]
+                                          } ]
+                                       }, {
+                                          "value" : [ " ","~"," " ]
+                                       }, {
+                                          "r" : "3249",
+                                          "s" : [ {
+                                             "value" : [ "\"Follow-up Plan\"" ]
+                                          } ]
+                                       } ]
+                                    } ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      )" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n  else\n      " ]
+                     }, {
+                        "r" : "3268",
+                        "s" : [ {
+                           "value" : [ "distinct" ]
+                        }, {
+                           "r" : "3296",
+                           "s" : [ {
+                              "value" : [ "(\n        " ]
+                           }, {
+                              "r" : "3296",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "r" : "3269",
+                                    "s" : [ {
+                                       "r" : "3270",
+                                       "s" : [ {
+                                          "s" : [ {
+                                             "value" : [ "AllVerifiedObservations" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ " ","O" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ "\n          " ]
+                              }, {
+                                 "r" : "3275",
+                                 "s" : [ {
+                                    "value" : [ "where " ]
+                                 }, {
+                                    "r" : "3275",
+                                    "s" : [ {
+                                       "r" : "3279",
+                                       "s" : [ {
+                                          "r" : "3277",
+                                          "s" : [ {
+                                             "r" : "3276",
+                                             "s" : [ {
+                                                "value" : [ "O" ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "." ]
+                                          }, {
+                                             "r" : "3277",
+                                             "s" : [ {
+                                                "value" : [ "code" ]
+                                             } ]
+                                          } ]
+                                       }, {
+                                          "value" : [ " in " ]
+                                       }, {
+                                          "r" : "3278",
+                                          "s" : [ {
+                                             "value" : [ "\"Colorectal Screening Modalities\"" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ "\n          or " ]
+                                    }, {
+                                       "r" : "3283",
+                                       "s" : [ {
+                                          "r" : "3285",
+                                          "s" : [ {
+                                             "r" : "3284",
+                                             "s" : [ {
+                                                "value" : [ "O" ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "." ]
+                                          }, {
+                                             "r" : "3285",
+                                             "s" : [ {
+                                                "value" : [ "code" ]
+                                             } ]
+                                          } ]
+                                       }, {
+                                          "value" : [ " ","~"," " ]
+                                       }, {
+                                          "r" : "3286",
+                                          "s" : [ {
+                                             "value" : [ "\"Follow-up Plan\"" ]
+                                          } ]
+                                       } ]
+                                    } ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      )" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3460",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3461",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3193",
+               "locator" : "547:3-559:7",
+               "type" : "If",
+               "resultTypeSpecifier" : {
+                  "localId" : "3305",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3306",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "condition" : {
+                  "localId" : "3197",
+                  "locator" : "547:6-547:41",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Not",
+                  "signature" : [ {
+                     "localId" : "3198",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "operand" : {
+                     "localId" : "3195",
+                     "locator" : "547:6-547:41",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "IsNull",
+                     "signature" : [ {
+                        "localId" : "3196",
+                        "name" : "{urn:hl7-org:elm-types:r1}Any",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : {
+                        "localId" : "3194",
+                        "locator" : "547:6-547:29",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "name" : "ScreeningHistoryLookback",
+                        "type" : "ParameterRef"
+                     }
+                  }
+               },
+               "then" : {
+                  "localId" : "3199",
+                  "locator" : "549:7-553:7",
+                  "type" : "Distinct",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3266",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3267",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ {
+                     "localId" : "3264",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3265",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "3259",
+                     "locator" : "549:15-553:7",
+                     "type" : "Query",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3262",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3263",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "source" : [ {
+                        "localId" : "3200",
+                        "locator" : "550:9-550:43",
+                        "alias" : "O",
+                        "resultTypeSpecifier" : {
+                           "localId" : "3236",
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "localId" : "3237",
+                              "name" : "{http://hl7.org/fhir}Observation",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        },
+                        "expression" : {
+                           "localId" : "3233",
+                           "locator" : "550:9-550:41",
+                           "name" : "AllVerifiedObservationsInLookback",
+                           "type" : "ExpressionRef",
+                           "resultTypeSpecifier" : {
+                              "localId" : "3234",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "3235",
+                                 "name" : "{http://hl7.org/fhir}Observation",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     } ],
+                     "let" : [ ],
+                     "relationship" : [ ],
+                     "where" : {
+                        "localId" : "3238",
+                        "locator" : "551:11-552:38",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "Or",
+                        "signature" : [ {
+                           "localId" : "3257",
+                           "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "3258",
+                           "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3242",
+                           "locator" : "551:17-551:59",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "InValueSet",
+                           "signature" : [ {
+                              "localId" : "3245",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "code" : {
+                              "localId" : "3243",
+                              "name" : "ToConcept",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "signature" : [ {
+                                 "localId" : "3244",
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : [ {
+                                 "localId" : "3240",
+                                 "locator" : "551:17-551:22",
+                                 "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "path" : "code",
+                                 "scope" : "O",
+                                 "type" : "Property"
+                              } ]
+                           },
+                           "valueset" : {
+                              "localId" : "3241",
+                              "locator" : "551:27-551:59",
+                              "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                              "name" : "Colorectal Screening Modalities",
+                              "preserve" : true
+                           }
+                        }, {
+                           "localId" : "3246",
+                           "locator" : "552:14-552:38",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "Equivalent",
+                           "signature" : [ {
+                              "localId" : "3255",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           }, {
+                              "localId" : "3256",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "operand" : [ {
+                              "localId" : "3250",
+                              "name" : "ToConcept",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "signature" : [ {
+                                 "localId" : "3251",
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : [ {
+                                 "localId" : "3248",
+                                 "locator" : "552:14-552:19",
+                                 "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "path" : "code",
+                                 "scope" : "O",
+                                 "type" : "Property"
+                              } ]
+                           }, {
+                              "localId" : "3253",
+                              "type" : "ToConcept",
+                              "signature" : [ {
+                                 "localId" : "3254",
+                                 "name" : "{urn:hl7-org:elm-types:r1}Code",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : {
+                                 "localId" : "3249",
+                                 "locator" : "552:23-552:38",
+                                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                                 "name" : "Follow-up Plan",
+                                 "type" : "CodeRef"
+                              }
+                           } ]
+                        } ]
+                     }
+                  }
+               },
+               "else" : {
+                  "localId" : "3268",
+                  "locator" : "555:7-559:7",
+                  "type" : "Distinct",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3303",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3304",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ {
+                     "localId" : "3301",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3302",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "3296",
+                     "locator" : "555:15-559:7",
+                     "type" : "Query",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3299",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3300",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "source" : [ {
+                        "localId" : "3269",
+                        "locator" : "556:9-556:33",
+                        "alias" : "O",
+                        "resultTypeSpecifier" : {
+                           "localId" : "3273",
+                           "type" : "ListTypeSpecifier",
+                           "elementType" : {
+                              "localId" : "3274",
+                              "name" : "{http://hl7.org/fhir}Observation",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        },
+                        "expression" : {
+                           "localId" : "3270",
+                           "locator" : "556:9-556:31",
+                           "name" : "AllVerifiedObservations",
+                           "type" : "ExpressionRef",
+                           "resultTypeSpecifier" : {
+                              "localId" : "3271",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "3272",
+                                 "name" : "{http://hl7.org/fhir}Observation",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     } ],
+                     "let" : [ ],
+                     "relationship" : [ ],
+                     "where" : {
+                        "localId" : "3275",
+                        "locator" : "557:11-558:38",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "Or",
+                        "signature" : [ {
+                           "localId" : "3294",
+                           "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "3295",
+                           "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3279",
+                           "locator" : "557:17-557:59",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "InValueSet",
+                           "signature" : [ {
+                              "localId" : "3282",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "code" : {
+                              "localId" : "3280",
+                              "name" : "ToConcept",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "signature" : [ {
+                                 "localId" : "3281",
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : [ {
+                                 "localId" : "3277",
+                                 "locator" : "557:17-557:22",
+                                 "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "path" : "code",
+                                 "scope" : "O",
+                                 "type" : "Property"
+                              } ]
+                           },
+                           "valueset" : {
+                              "localId" : "3278",
+                              "locator" : "557:27-557:59",
+                              "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                              "name" : "Colorectal Screening Modalities",
+                              "preserve" : true
+                           }
+                        }, {
+                           "localId" : "3283",
+                           "locator" : "558:14-558:38",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "type" : "Equivalent",
+                           "signature" : [ {
+                              "localId" : "3292",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           }, {
+                              "localId" : "3293",
+                              "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                              "type" : "NamedTypeSpecifier"
+                           } ],
+                           "operand" : [ {
+                              "localId" : "3287",
+                              "name" : "ToConcept",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "signature" : [ {
+                                 "localId" : "3288",
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : [ {
+                                 "localId" : "3285",
+                                 "locator" : "558:14-558:19",
+                                 "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "path" : "code",
+                                 "scope" : "O",
+                                 "type" : "Property"
+                              } ]
+                           }, {
+                              "localId" : "3290",
+                              "type" : "ToConcept",
+                              "signature" : [ {
+                                 "localId" : "3291",
+                                 "name" : "{urn:hl7-org:elm-types:r1}Code",
+                                 "type" : "NamedTypeSpecifier"
+                              } ],
+                              "operand" : {
+                                 "localId" : "3286",
+                                 "locator" : "558:23-558:38",
+                                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                                 "name" : "Follow-up Plan",
+                                 "type" : "CodeRef"
+                              }
+                           } ]
+                        } ]
+                     }
+                  }
+               }
+            }
+         }, {
+            "localId" : "3189",
+            "locator" : "609:1-612:49",
             "name" : "ColonoscopyObservations",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3093",
+                  "r" : "3189",
                   "s" : [ {
                      "value" : [ "","define ","ColonoscopyObservations",":\n  " ]
                   }, {
-                     "r" : "3117",
+                     "r" : "3335",
                      "s" : [ {
-                        "r" : "3097",
                         "s" : [ {
-                           "r" : "3094",
+                           "r" : "3190",
                            "s" : [ {
-                              "value" : [ "CRCSMCommon" ]
-                           } ]
-                        }, {
-                           "value" : [ "." ]
-                        }, {
-                           "r" : "3097",
-                           "s" : [ {
-                              "value" : [ "VerifiedObservations","(" ]
-                           }, {
-                              "r" : "3095",
+                              "r" : "3309",
                               "s" : [ {
-                                 "value" : [ "\"Colonoscopy Study\"" ]
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
                               } ]
                            }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "r" : "3096",
-                              "s" : [ {
-                                 "value" : [ "ScreeningHistoryLookback" ]
-                              } ]
-                           }, {
-                              "value" : [ ")" ]
+                              "value" : [ " ","O" ]
                            } ]
                         } ]
                      }, {
-                        "value" : [ "\n  union\n  " ]
+                        "value" : [ "\n    " ]
                      }, {
-                        "r" : "3107",
+                        "r" : "3314",
                         "s" : [ {
-                           "r" : "3104",
-                           "s" : [ {
-                              "value" : [ "CRCSMCommon" ]
-                           } ]
+                           "value" : [ "where " ]
                         }, {
-                           "value" : [ "." ]
-                        }, {
-                           "r" : "3107",
+                           "r" : "3314",
                            "s" : [ {
-                              "value" : [ "VerifiedObservations","(" ]
-                           }, {
-                              "r" : "3105",
+                              "r" : "3318",
                               "s" : [ {
-                                 "value" : [ "\"Colonoscopy Study Observation\"" ]
+                                 "r" : "3316",
+                                 "s" : [ {
+                                    "r" : "3315",
+                                    "s" : [ {
+                                       "value" : [ "O" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "3316",
+                                    "s" : [ {
+                                       "value" : [ "code" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ " in " ]
+                              }, {
+                                 "r" : "3317",
+                                 "s" : [ {
+                                    "value" : [ "\"Colonoscopy Study\"" ]
+                                 } ]
                               } ]
                            }, {
-                              "value" : [ ", " ]
+                              "value" : [ "\n      or " ]
                            }, {
-                              "r" : "3106",
+                              "r" : "3322",
                               "s" : [ {
-                                 "value" : [ "ScreeningHistoryLookback" ]
+                                 "r" : "3324",
+                                 "s" : [ {
+                                    "r" : "3323",
+                                    "s" : [ {
+                                       "value" : [ "O" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "3324",
+                                    "s" : [ {
+                                       "value" : [ "code" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ " ","~"," " ]
+                              }, {
+                                 "r" : "3325",
+                                 "s" : [ {
+                                    "value" : [ "\"Colonoscopy Study Observation\"" ]
+                                 } ]
                               } ]
-                           }, {
-                              "value" : [ ")" ]
                            } ]
                         } ]
                      } ]
@@ -28303,233 +29792,329 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3519",
+               "localId" : "3640",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3520",
+                  "localId" : "3641",
                   "name" : "{http://hl7.org/fhir}Observation",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3117",
-               "locator" : "575:3-577:93",
-               "type" : "Union",
+               "localId" : "3335",
+               "locator" : "610:3-612:49",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3122",
+                  "localId" : "3336",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3123",
+                     "localId" : "3337",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3118",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3119",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               }, {
-                  "localId" : "3120",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3121",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3190",
+                  "locator" : "610:3-610:41",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3312",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3313",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3309",
+                     "locator" : "610:3-610:39",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3310",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3311",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
                   }
                } ],
-               "operand" : [ {
-                  "localId" : "3097",
-                  "locator" : "575:3-575:81",
-                  "name" : "VerifiedObservations",
-                  "libraryName" : "CRCSMCommon",
-                  "type" : "FunctionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3102",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3103",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3314",
+                  "locator" : "611:5-612:49",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Or",
                   "signature" : [ {
-                     "localId" : "3098",
-                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "localId" : "3333",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "3099",
-                     "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                     "localId" : "3334",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "3095",
-                     "locator" : "575:36-575:54",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                     "name" : "Colonoscopy Study",
-                     "preserve" : true,
-                     "type" : "ValueSetRef"
-                  }, {
-                     "localId" : "3096",
-                     "locator" : "575:57-575:80",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "name" : "ScreeningHistoryLookback",
-                     "type" : "ParameterRef"
-                  } ]
-               }, {
-                  "localId" : "3107",
-                  "locator" : "577:3-577:93",
-                  "name" : "VerifiedObservations",
-                  "libraryName" : "CRCSMCommon",
-                  "type" : "FunctionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3115",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3116",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "signature" : [ {
-                     "localId" : "3111",
-                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
-                     "localId" : "3112",
-                     "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "type" : "NamedTypeSpecifier"
-                  } ],
-                  "operand" : [ {
-                     "localId" : "3109",
-                     "type" : "ToConcept",
+                     "localId" : "3318",
+                     "locator" : "611:11-611:39",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "InValueSet",
                      "signature" : [ {
-                        "localId" : "3110",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "localId" : "3321",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
                         "type" : "NamedTypeSpecifier"
                      } ],
-                     "operand" : {
-                        "localId" : "3105",
-                        "locator" : "577:36-577:66",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                        "name" : "Colonoscopy Study Observation",
-                        "type" : "CodeRef"
+                     "code" : {
+                        "localId" : "3319",
+                        "name" : "ToConcept",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "signature" : [ {
+                           "localId" : "3320",
+                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3316",
+                           "locator" : "611:11-611:16",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "code",
+                           "scope" : "O",
+                           "type" : "Property"
+                        } ]
+                     },
+                     "valueset" : {
+                        "localId" : "3317",
+                        "locator" : "611:21-611:39",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "name" : "Colonoscopy Study",
+                        "preserve" : true
                      }
                   }, {
-                     "localId" : "3106",
-                     "locator" : "577:69-577:92",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "name" : "ScreeningHistoryLookback",
-                     "type" : "ParameterRef"
+                     "localId" : "3322",
+                     "locator" : "612:10-612:49",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "Equivalent",
+                     "signature" : [ {
+                        "localId" : "3331",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                        "type" : "NamedTypeSpecifier"
+                     }, {
+                        "localId" : "3332",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3326",
+                        "name" : "ToConcept",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "signature" : [ {
+                           "localId" : "3327",
+                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3324",
+                           "locator" : "612:10-612:15",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "code",
+                           "scope" : "O",
+                           "type" : "Property"
+                        } ]
+                     }, {
+                        "localId" : "3329",
+                        "type" : "ToConcept",
+                        "signature" : [ {
+                           "localId" : "3330",
+                           "name" : "{urn:hl7-org:elm-types:r1}Code",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : {
+                           "localId" : "3325",
+                           "locator" : "612:19-612:49",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                           "name" : "Colonoscopy Study Observation",
+                           "type" : "CodeRef"
+                        }
+                     } ]
                   } ]
-               } ]
+               }
             }
          }, {
-            "localId" : "3143",
-            "locator" : "613:1-614:78",
+            "localId" : "3357",
+            "locator" : "651:1-653:35",
             "name" : "FollowUpObservations",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3143",
+                  "r" : "3357",
                   "s" : [ {
-                     "value" : [ "//Follow Up\n","define ","FollowUpObservations",":\n  " ]
+                     "value" : [ "//Follow Up\n","define ","FollowUpObservations",":\n    " ]
                   }, {
-                     "r" : "3147",
+                     "r" : "3375",
                      "s" : [ {
-                        "r" : "3144",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3358",
+                           "s" : [ {
+                              "r" : "3359",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","O" ]
+                           } ]
                         } ]
                      }, {
-                        "value" : [ "." ]
+                        "value" : [ "\n    " ]
                      }, {
-                        "r" : "3147",
+                        "r" : "3364",
                         "s" : [ {
-                           "value" : [ "VerifiedObservations","(" ]
+                           "value" : [ "where " ]
                         }, {
-                           "r" : "3145",
+                           "r" : "3364",
                            "s" : [ {
-                              "value" : [ "\"Follow-up Plan\"" ]
+                              "r" : "3366",
+                              "s" : [ {
+                                 "r" : "3365",
+                                 "s" : [ {
+                                    "value" : [ "O" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3366",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","~"," " ]
+                           }, {
+                              "r" : "3367",
+                              "s" : [ {
+                                 "value" : [ "\"Follow-up Plan\"" ]
+                              } ]
                            } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3146",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
                         } ]
                      } ]
                   } ]
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3654",
+               "localId" : "3841",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3655",
+                  "localId" : "3842",
                   "name" : "{http://hl7.org/fhir}Observation",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3147",
-               "locator" : "614:3-614:78",
-               "name" : "VerifiedObservations",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
+               "localId" : "3375",
+               "locator" : "652:5-653:35",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3155",
+                  "localId" : "3376",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3156",
+                     "localId" : "3377",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3151",
-                  "name" : "{urn:hl7-org:elm-types:r1}Concept",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3152",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3358",
+                  "locator" : "652:5-652:43",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3362",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3363",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3359",
+                     "locator" : "652:5-652:41",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3360",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3361",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
                } ],
-               "operand" : [ {
-                  "localId" : "3149",
-                  "type" : "ToConcept",
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3364",
+                  "locator" : "653:5-653:35",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Equivalent",
                   "signature" : [ {
-                     "localId" : "3150",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "localId" : "3373",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "3374",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
                      "type" : "NamedTypeSpecifier"
                   } ],
-                  "operand" : {
-                     "localId" : "3145",
-                     "locator" : "614:36-614:51",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "name" : "Follow-up Plan",
-                     "type" : "CodeRef"
-                  }
-               }, {
-                  "localId" : "3146",
-                  "locator" : "614:54-614:77",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
+                  "operand" : [ {
+                     "localId" : "3368",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3369",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3366",
+                        "locator" : "653:11-653:16",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "O",
+                        "type" : "Property"
+                     } ]
+                  }, {
+                     "localId" : "3371",
+                     "type" : "ToConcept",
+                     "signature" : [ {
+                        "localId" : "3372",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : {
+                        "localId" : "3367",
+                        "locator" : "653:20-653:35",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "Follow-up Plan",
+                        "type" : "CodeRef"
+                     }
+                  } ]
+               }
             }
          }, {
             "localId" : "3067",
-            "locator" : "565:1-569:77",
+            "locator" : "599:1-603:77",
             "name" : "ColonoscopyDiagnosticReportsWithResults",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -28540,12 +30125,12 @@
                   "s" : [ {
                      "value" : [ "","define ","ColonoscopyDiagnosticReportsWithResults",":\n  " ]
                   }, {
-                     "r" : "3174",
+                     "r" : "3395",
                      "s" : [ {
                         "s" : [ {
                            "r" : "3068",
                            "s" : [ {
-                              "r" : "3083",
+                              "r" : "3179",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "ColonoscopyDiagnosticReports" ]
@@ -28558,37 +30143,37 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3088",
+                        "r" : "3184",
                         "s" : [ {
                            "value" : [ "where\n      " ]
                         }, {
-                           "r" : "3088",
+                           "r" : "3184",
                            "s" : [ {
-                              "r" : "3089",
+                              "r" : "3185",
                               "s" : [ {
                                  "value" : [ "exists " ]
                               }, {
-                                 "r" : "3129",
+                                 "r" : "3343",
                                  "s" : [ {
-                                    "r" : "3090",
+                                    "r" : "3186",
                                     "s" : [ {
                                        "value" : [ "CRCSMCommon" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3129",
+                                    "r" : "3343",
                                     "s" : [ {
                                        "value" : [ "CollateConclusionCodes","(" ]
                                     }, {
-                                       "r" : "3091",
+                                       "r" : "3187",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "," ]
                                     }, {
-                                       "r" : "3126",
+                                       "r" : "3340",
                                        "s" : [ {
                                           "value" : [ "ColonoscopyObservations" ]
                                        } ]
@@ -28600,31 +30185,31 @@
                            }, {
                               "value" : [ " or\n      " ]
                            }, {
-                              "r" : "3139",
+                              "r" : "3353",
                               "s" : [ {
                                  "value" : [ "exists " ]
                               }, {
-                                 "r" : "3162",
+                                 "r" : "3383",
                                  "s" : [ {
-                                    "r" : "3140",
+                                    "r" : "3354",
                                     "s" : [ {
                                        "value" : [ "CRCSMCommon" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3162",
+                                    "r" : "3383",
                                     "s" : [ {
                                        "value" : [ "ValueQuantityFromObservation","(" ]
                                     }, {
-                                       "r" : "3141",
+                                       "r" : "3355",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "," ]
                                     }, {
-                                       "r" : "3159",
+                                       "r" : "3380",
                                        "s" : [ {
                                           "value" : [ "FollowUpObservations" ]
                                        } ]
@@ -28640,50 +30225,50 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3515",
+               "localId" : "3636",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3516",
+                  "localId" : "3637",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3174",
-               "locator" : "566:3-569:77",
+               "localId" : "3395",
+               "locator" : "600:3-603:77",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3175",
+                  "localId" : "3396",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3176",
+                     "localId" : "3397",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
                   "localId" : "3068",
-                  "locator" : "566:3-566:32",
+                  "locator" : "600:3-600:32",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3086",
+                     "localId" : "3182",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3087",
+                        "localId" : "3183",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3083",
-                     "locator" : "566:3-566:30",
+                     "localId" : "3179",
+                     "locator" : "600:3-600:30",
                      "name" : "ColonoscopyDiagnosticReports",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3084",
+                        "localId" : "3180",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3085",
+                           "localId" : "3181",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -28693,77 +30278,77 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3088",
-                  "locator" : "567:5-569:77",
+                  "localId" : "3184",
+                  "locator" : "601:5-603:77",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Or",
                   "signature" : [ {
-                     "localId" : "3172",
+                     "localId" : "3393",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "3173",
+                     "localId" : "3394",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "3089",
-                     "locator" : "568:7-568:74",
+                     "localId" : "3185",
+                     "locator" : "602:7-602:74",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Exists",
                      "signature" : [ {
-                        "localId" : "3137",
+                        "localId" : "3351",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3138",
+                           "localId" : "3352",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : {
-                        "localId" : "3129",
-                        "locator" : "568:14-568:74",
+                        "localId" : "3343",
+                        "locator" : "602:14-602:74",
                         "name" : "CollateConclusionCodes",
                         "libraryName" : "CRCSMCommon",
                         "type" : "FunctionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3135",
+                           "localId" : "3349",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3136",
+                              "localId" : "3350",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "signature" : [ {
-                           "localId" : "3130",
+                           "localId" : "3344",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }, {
-                           "localId" : "3131",
+                           "localId" : "3345",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3132",
+                              "localId" : "3346",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "3091",
-                           "locator" : "568:49",
+                           "localId" : "3187",
+                           "locator" : "602:49",
                            "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                            "name" : "D",
                            "type" : "AliasRef"
                         }, {
-                           "localId" : "3126",
-                           "locator" : "568:51-568:73",
+                           "localId" : "3340",
+                           "locator" : "602:51-602:73",
                            "name" : "ColonoscopyObservations",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3127",
+                              "localId" : "3341",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3128",
+                                 "localId" : "3342",
                                  "name" : "{http://hl7.org/fhir}Observation",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -28771,63 +30356,63 @@
                         } ]
                      }
                   }, {
-                     "localId" : "3139",
-                     "locator" : "569:7-569:77",
+                     "localId" : "3353",
+                     "locator" : "603:7-603:77",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Exists",
                      "signature" : [ {
-                        "localId" : "3170",
+                        "localId" : "3391",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3171",
+                           "localId" : "3392",
                            "name" : "{http://hl7.org/fhir}Quantity",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : {
-                        "localId" : "3162",
-                        "locator" : "569:14-569:77",
+                        "localId" : "3383",
+                        "locator" : "603:14-603:77",
                         "name" : "ValueQuantityFromObservation",
                         "libraryName" : "CRCSMCommon",
                         "type" : "FunctionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3168",
+                           "localId" : "3389",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3169",
+                              "localId" : "3390",
                               "name" : "{http://hl7.org/fhir}Quantity",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "signature" : [ {
-                           "localId" : "3163",
+                           "localId" : "3384",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }, {
-                           "localId" : "3164",
+                           "localId" : "3385",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3165",
+                              "localId" : "3386",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "3141",
-                           "locator" : "569:55",
+                           "localId" : "3355",
+                           "locator" : "603:55",
                            "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                            "name" : "D",
                            "type" : "AliasRef"
                         }, {
-                           "localId" : "3159",
-                           "locator" : "569:57-569:76",
+                           "localId" : "3380",
+                           "locator" : "603:57-603:76",
                            "name" : "FollowUpObservations",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3160",
+                              "localId" : "3381",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3161",
+                                 "localId" : "3382",
                                  "name" : "{http://hl7.org/fhir}Observation",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -28850,12 +30435,12 @@
                   "s" : [ {
                      "value" : [ "","define ","PrecancerousPolypsInAnyPreviousColonoscopy",":\n  " ]
                   }, {
-                     "r" : "3213",
+                     "r" : "3434",
                      "s" : [ {
                         "s" : [ {
                            "r" : "3065",
                            "s" : [ {
-                              "r" : "3179",
+                              "r" : "3400",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "ColonoscopyDiagnosticReportsWithResults" ]
@@ -28871,31 +30456,31 @@
                         "s" : [ {
                            "value" : [ "let " ]
                         }, {
-                           "r" : "3184",
+                           "r" : "3405",
                            "s" : [ {
                               "value" : [ "cC",": " ]
                            }, {
-                              "r" : "3190",
+                              "r" : "3411",
                               "s" : [ {
-                                 "r" : "3185",
+                                 "r" : "3406",
                                  "s" : [ {
                                     "value" : [ "CRCSMCommon" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "3190",
+                                 "r" : "3411",
                                  "s" : [ {
                                     "value" : [ "CollateConclusionCodes","(" ]
                                  }, {
-                                    "r" : "3186",
+                                    "r" : "3407",
                                     "s" : [ {
                                        "value" : [ "D" ]
                                     } ]
                                  }, {
                                     "value" : [ "," ]
                                  }, {
-                                    "r" : "3187",
+                                    "r" : "3408",
                                     "s" : [ {
                                        "value" : [ "ColonoscopyObservations" ]
                                     } ]
@@ -28908,20 +30493,20 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3204",
+                        "r" : "3425",
                         "s" : [ {
                            "value" : [ "where " ]
                         }, {
-                           "r" : "3204",
+                           "r" : "3425",
                            "s" : [ {
-                              "r" : "3200",
+                              "r" : "3421",
                               "s" : [ {
                                  "value" : [ "cC" ]
                               } ]
                            }, {
                               "value" : [ " in " ]
                            }, {
-                              "r" : "3203",
+                              "r" : "3424",
                               "s" : [ {
                                  "value" : [ "\"Potentially Precancerous Polyp SNOMED\"" ]
                               } ]
@@ -28932,23 +30517,23 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3227",
+               "localId" : "3448",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3228",
+                  "localId" : "3449",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3213",
+               "localId" : "3434",
                "locator" : "511:3-513:55",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3214",
+                  "localId" : "3435",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3215",
+                     "localId" : "3436",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -28958,24 +30543,24 @@
                   "locator" : "511:3-511:43",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3182",
+                     "localId" : "3403",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3183",
+                        "localId" : "3404",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3179",
+                     "localId" : "3400",
                      "locator" : "511:3-511:41",
                      "name" : "ColonoscopyDiagnosticReportsWithResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3180",
+                        "localId" : "3401",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3181",
+                           "localId" : "3402",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -28983,62 +30568,62 @@
                   }
                } ],
                "let" : [ {
-                  "localId" : "3184",
+                  "localId" : "3405",
                   "locator" : "512:9-512:73",
                   "identifier" : "cC",
                   "resultTypeSpecifier" : {
-                     "localId" : "3198",
+                     "localId" : "3419",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3199",
+                        "localId" : "3420",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3190",
+                     "localId" : "3411",
                      "locator" : "512:13-512:73",
                      "name" : "CollateConclusionCodes",
                      "libraryName" : "CRCSMCommon",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3196",
+                        "localId" : "3417",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3197",
+                           "localId" : "3418",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3191",
+                        "localId" : "3412",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "3192",
+                        "localId" : "3413",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3193",
+                           "localId" : "3414",
                            "name" : "{http://hl7.org/fhir}Observation",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3186",
+                        "localId" : "3407",
                         "locator" : "512:48",
                         "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                         "name" : "D",
                         "type" : "AliasRef"
                      }, {
-                        "localId" : "3187",
+                        "localId" : "3408",
                         "locator" : "512:50-512:72",
                         "name" : "ColonoscopyObservations",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3188",
+                           "localId" : "3409",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3189",
+                              "localId" : "3410",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -29048,35 +30633,35 @@
                } ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3204",
+                  "localId" : "3425",
                   "locator" : "513:5-513:55",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "AnyInValueSet",
                   "signature" : [ {
-                     "localId" : "3211",
+                     "localId" : "3432",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3212",
+                        "localId" : "3433",
                         "name" : "{urn:hl7-org:elm-types:r1}Concept",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "codes" : {
-                     "localId" : "3205",
+                     "localId" : "3426",
                      "type" : "Query",
                      "source" : [ {
-                        "localId" : "3206",
+                        "localId" : "3427",
                         "alias" : "X",
                         "expression" : {
-                           "localId" : "3200",
+                           "localId" : "3421",
                            "locator" : "513:11-513:12",
                            "name" : "cC",
                            "type" : "QueryLetRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3201",
+                              "localId" : "3422",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3202",
+                                 "localId" : "3423",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -29086,20 +30671,20 @@
                      "let" : [ ],
                      "relationship" : [ ],
                      "return" : {
-                        "localId" : "3207",
+                        "localId" : "3428",
                         "distinct" : false,
                         "expression" : {
-                           "localId" : "3209",
+                           "localId" : "3430",
                            "name" : "ToConcept",
                            "libraryName" : "FHIRHelpers",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "3210",
+                              "localId" : "3431",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3208",
+                              "localId" : "3429",
                               "name" : "X",
                               "type" : "AliasRef"
                            } ]
@@ -29107,7 +30692,7 @@
                      }
                   },
                   "valueset" : {
-                     "localId" : "3203",
+                     "localId" : "3424",
                      "locator" : "513:17-513:55",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "Potentially Precancerous Polyp SNOMED",
@@ -29147,7 +30732,7 @@
                         "s" : [ {
                            "value" : [ "exists " ]
                         }, {
-                           "r" : "3218",
+                           "r" : "3439",
                            "s" : [ {
                               "value" : [ "PrecancerousPolypsInAnyPreviousColonoscopy" ]
                            } ]
@@ -29162,11 +30747,11 @@
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Or",
                "signature" : [ {
-                  "localId" : "3223",
+                  "localId" : "3444",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3224",
+                  "localId" : "3445",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                } ],
@@ -29205,24 +30790,24 @@
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Exists",
                   "signature" : [ {
-                     "localId" : "3221",
+                     "localId" : "3442",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3222",
+                        "localId" : "3443",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "3218",
+                     "localId" : "3439",
                      "locator" : "505:60-505:101",
                      "name" : "PrecancerousPolypsInAnyPreviousColonoscopy",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3219",
+                        "localId" : "3440",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3220",
+                           "localId" : "3441",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -29231,1047 +30816,334 @@
                } ]
             }
          }, {
-            "localId" : "3230",
-            "locator" : "522:1-523:89",
-            "name" : "ColorectalCancerScreeningDiagnosticReports",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3230",
-                  "s" : [ {
-                     "value" : [ "//TODO consider whether lookback of 10 years is appropriate\n//TODO generalize to include history of precancerous polyps from other modalities (CT colonography and flex sig)\n\n//------------------------------------------------------------------------------\n// Colorectal screening modalities\n//------------------------------------------------------------------------------\n\n//TODO Use single retrieve for all completed Diagnostic reports in lookback and then filter by modality.\n","define ","ColorectalCancerScreeningDiagnosticReports",":\n  " ]
-                  }, {
-                     "r" : "3241",
-                     "s" : [ {
-                        "r" : "3231",
-                        "s" : [ {
-                           "value" : [ "Common" ]
-                        } ]
-                     }, {
-                        "value" : [ "." ]
-                     }, {
-                        "r" : "3241",
-                        "s" : [ {
-                           "value" : [ "CompletedDiagnosticReport","(" ]
-                        }, {
-                           "r" : "3234",
-                           "s" : [ {
-                              "value" : [ "[","DiagnosticReport",": " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "\"Colorectal Screening Modalities\"" ]
-                              } ]
-                           }, {
-                              "value" : [ "]" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3248",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3249",
-                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3241",
-               "locator" : "523:3-523:89",
-               "name" : "CompletedDiagnosticReport",
-               "libraryName" : "Common",
-               "type" : "FunctionRef",
-               "resultTypeSpecifier" : {
-                  "localId" : "3246",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3247",
-                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3242",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3243",
-                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "operand" : [ {
-                  "localId" : "3234",
-                  "locator" : "523:36-523:88",
-                  "dataType" : "{http://hl7.org/fhir}DiagnosticReport",
-                  "templateId" : "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-                  "codeProperty" : "code",
-                  "codeComparator" : "in",
-                  "type" : "Retrieve",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3239",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3240",
-                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "codes" : {
-                     "localId" : "3233",
-                     "locator" : "523:55-523:87",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                     "name" : "Colorectal Screening Modalities",
-                     "preserve" : true,
-                     "type" : "ValueSetRef"
-                  },
-                  "include" : [ ],
-                  "codeFilter" : [ ],
-                  "dateFilter" : [ ],
-                  "otherFilter" : [ ]
-               } ]
-            }
-         }, {
-            "localId" : "3251",
-            "locator" : "525:1-526:54",
-            "name" : "AllCompletedDiagnosticReport",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3251",
-                  "s" : [ {
-                     "value" : [ "","define ","AllCompletedDiagnosticReport",":\n  " ]
-                  }, {
-                     "r" : "3256",
-                     "s" : [ {
-                        "r" : "3252",
-                        "s" : [ {
-                           "value" : [ "Common" ]
-                        } ]
-                     }, {
-                        "value" : [ "." ]
-                     }, {
-                        "r" : "3256",
-                        "s" : [ {
-                           "value" : [ "CompletedDiagnosticReport","(" ]
-                        }, {
-                           "r" : "3253",
-                           "s" : [ {
-                              "value" : [ "[","DiagnosticReport","]" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3263",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3264",
-                  "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3256",
-               "locator" : "526:3-526:54",
-               "name" : "CompletedDiagnosticReport",
-               "libraryName" : "Common",
-               "type" : "FunctionRef",
-               "resultTypeSpecifier" : {
-                  "localId" : "3261",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3262",
-                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3257",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3258",
-                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "operand" : [ {
-                  "localId" : "3253",
-                  "locator" : "526:36-526:53",
-                  "dataType" : "{http://hl7.org/fhir}DiagnosticReport",
-                  "templateId" : "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-                  "type" : "Retrieve",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3254",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3255",
-                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "include" : [ ],
-                  "codeFilter" : [ ],
-                  "dateFilter" : [ ],
-                  "otherFilter" : [ ]
-               } ]
-            }
-         }, {
-            "localId" : "3268",
-            "locator" : "543:1-544:87",
-            "name" : "FOBTObservations",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3268",
-                  "s" : [ {
-                     "value" : [ "","define ","FOBTObservations",":\n  " ]
-                  }, {
-                     "r" : "3272",
-                     "s" : [ {
-                        "r" : "3269",
-                        "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
-                        } ]
-                     }, {
-                        "value" : [ "." ]
-                     }, {
-                        "r" : "3272",
-                        "s" : [ {
-                           "value" : [ "VerifiedObservations","(" ]
-                        }, {
-                           "r" : "3270",
-                           "s" : [ {
-                              "value" : [ "\"Fecal Occult Blood Test\"" ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3271",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3448",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3449",
-                  "name" : "{http://hl7.org/fhir}Observation",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3272",
-               "locator" : "544:3-544:87",
-               "name" : "VerifiedObservations",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
-               "resultTypeSpecifier" : {
-                  "localId" : "3277",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3278",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3273",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3274",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
-               } ],
-               "operand" : [ {
-                  "localId" : "3270",
-                  "locator" : "544:36-544:60",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Fecal Occult Blood Test",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3271",
-                  "locator" : "544:63-544:86",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
-            }
-         }, {
-            "localId" : "3285",
-            "locator" : "558:1-559:77",
-            "name" : "StoolDNAFITObservations",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3285",
-                  "s" : [ {
-                     "value" : [ "","define ","StoolDNAFITObservations",":\n  " ]
-                  }, {
-                     "r" : "3289",
-                     "s" : [ {
-                        "r" : "3286",
-                        "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
-                        } ]
-                     }, {
-                        "value" : [ "." ]
-                     }, {
-                        "r" : "3289",
-                        "s" : [ {
-                           "value" : [ "VerifiedObservations","(" ]
-                        }, {
-                           "r" : "3287",
-                           "s" : [ {
-                              "value" : [ "\"Stool DNA-FIT\"" ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3288",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3505",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3506",
-                  "name" : "{http://hl7.org/fhir}Observation",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3289",
-               "locator" : "559:3-559:77",
-               "name" : "VerifiedObservations",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
-               "resultTypeSpecifier" : {
-                  "localId" : "3294",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3295",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3290",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3291",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
-               } ],
-               "operand" : [ {
-                  "localId" : "3287",
-                  "locator" : "559:36-559:50",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Stool DNA-FIT",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3288",
-                  "locator" : "559:53-559:76",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
-            }
-         }, {
-            "localId" : "3319",
-            "locator" : "591:1-592:85",
-            "name" : "CTColonographyObservations",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3319",
-                  "s" : [ {
-                     "value" : [ "","define ","CTColonographyObservations",":\n  " ]
-                  }, {
-                     "r" : "3323",
-                     "s" : [ {
-                        "r" : "3320",
-                        "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
-                        } ]
-                     }, {
-                        "value" : [ "." ]
-                     }, {
-                        "r" : "3323",
-                        "s" : [ {
-                           "value" : [ "VerifiedObservations","(" ]
-                        }, {
-                           "r" : "3321",
-                           "s" : [ {
-                              "value" : [ "\"CT Colonography Study\"" ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3322",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3576",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3577",
-                  "name" : "{http://hl7.org/fhir}Observation",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3323",
-               "locator" : "592:3-592:85",
-               "name" : "VerifiedObservations",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
-               "resultTypeSpecifier" : {
-                  "localId" : "3328",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3329",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3324",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3325",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
-               } ],
-               "operand" : [ {
-                  "localId" : "3321",
-                  "locator" : "592:36-592:58",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "CT Colonography Study",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3322",
-                  "locator" : "592:61-592:84",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
-            }
-         }, {
-            "localId" : "3348",
-            "locator" : "607:1-610:104",
-            "name" : "FlexSigObservations",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3348",
-                  "s" : [ {
-                     "value" : [ "","define ","FlexSigObservations",":\n  " ]
-                  }, {
-                     "r" : "3372",
-                     "s" : [ {
-                        "r" : "3352",
-                        "s" : [ {
-                           "r" : "3349",
-                           "s" : [ {
-                              "value" : [ "CRCSMCommon" ]
-                           } ]
-                        }, {
-                           "value" : [ "." ]
-                        }, {
-                           "r" : "3352",
-                           "s" : [ {
-                              "value" : [ "VerifiedObservations","(" ]
-                           }, {
-                              "r" : "3350",
-                              "s" : [ {
-                                 "value" : [ "\"Flexible Sigmoidoscopy Study\"" ]
-                              } ]
-                           }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "r" : "3351",
-                              "s" : [ {
-                                 "value" : [ "ScreeningHistoryLookback" ]
-                              } ]
-                           }, {
-                              "value" : [ ")" ]
-                           } ]
-                        } ]
-                     }, {
-                        "value" : [ "\n  union\n  " ]
-                     }, {
-                        "r" : "3362",
-                        "s" : [ {
-                           "r" : "3359",
-                           "s" : [ {
-                              "value" : [ "CRCSMCommon" ]
-                           } ]
-                        }, {
-                           "value" : [ "." ]
-                        }, {
-                           "r" : "3362",
-                           "s" : [ {
-                              "value" : [ "VerifiedObservations","(" ]
-                           }, {
-                              "r" : "3360",
-                              "s" : [ {
-                                 "value" : [ "\"Flexible Sigmoidoscopy Study Observation\"" ]
-                              } ]
-                           }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "r" : "3361",
-                              "s" : [ {
-                                 "value" : [ "ScreeningHistoryLookback" ]
-                              } ]
-                           }, {
-                              "value" : [ ")" ]
-                           } ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3652",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3653",
-                  "name" : "{http://hl7.org/fhir}Observation",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3372",
-               "locator" : "608:3-610:104",
-               "type" : "Union",
-               "resultTypeSpecifier" : {
-                  "localId" : "3377",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3378",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3373",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3374",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               }, {
-                  "localId" : "3375",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3376",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "operand" : [ {
-                  "localId" : "3352",
-                  "locator" : "608:3-608:92",
-                  "name" : "VerifiedObservations",
-                  "libraryName" : "CRCSMCommon",
-                  "type" : "FunctionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3357",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3358",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "signature" : [ {
-                     "localId" : "3353",
-                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
-                     "localId" : "3354",
-                     "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "type" : "NamedTypeSpecifier"
-                  } ],
-                  "operand" : [ {
-                     "localId" : "3350",
-                     "locator" : "608:36-608:65",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                     "name" : "Flexible Sigmoidoscopy Study",
-                     "preserve" : true,
-                     "type" : "ValueSetRef"
-                  }, {
-                     "localId" : "3351",
-                     "locator" : "608:68-608:91",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "name" : "ScreeningHistoryLookback",
-                     "type" : "ParameterRef"
-                  } ]
-               }, {
-                  "localId" : "3362",
-                  "locator" : "610:3-610:104",
-                  "name" : "VerifiedObservations",
-                  "libraryName" : "CRCSMCommon",
-                  "type" : "FunctionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3370",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3371",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "signature" : [ {
-                     "localId" : "3366",
-                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
-                     "localId" : "3367",
-                     "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "type" : "NamedTypeSpecifier"
-                  } ],
-                  "operand" : [ {
-                     "localId" : "3364",
-                     "type" : "ToConcept",
-                     "signature" : [ {
-                        "localId" : "3365",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     } ],
-                     "operand" : {
-                        "localId" : "3360",
-                        "locator" : "610:36-610:77",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                        "name" : "Flexible Sigmoidoscopy Study Observation",
-                        "type" : "CodeRef"
-                     }
-                  }, {
-                     "localId" : "3361",
-                     "locator" : "610:80-610:103",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                     "name" : "ScreeningHistoryLookback",
-                     "type" : "ParameterRef"
-                  } ]
-               } ]
-            }
-         }, {
-            "localId" : "3266",
-            "locator" : "528:1-529:137",
-            "name" : "ColorectalCancerScreeningObservations",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "3266",
-                  "s" : [ {
-                     "value" : [ "","define ","ColorectalCancerScreeningObservations",":\n  " ]
-                  }, {
-                     "r" : "3384",
-                     "s" : [ {
-                        "r" : "3340",
-                        "s" : [ {
-                           "r" : "3311",
-                           "s" : [ {
-                              "r" : "3301",
-                              "s" : [ {
-                                 "r" : "3281",
-                                 "s" : [ {
-                                    "value" : [ "FOBTObservations" ]
-                                 } ]
-                              }, {
-                                 "value" : [ " union " ]
-                              }, {
-                                 "r" : "3298",
-                                 "s" : [ {
-                                    "value" : [ "StoolDNAFITObservations" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " union " ]
-                           }, {
-                              "r" : "3308",
-                              "s" : [ {
-                                 "value" : [ "ColonoscopyObservations" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " union " ]
-                        }, {
-                           "r" : "3332",
-                           "s" : [ {
-                              "value" : [ "CTColonographyObservations" ]
-                           } ]
-                        } ]
-                     }, {
-                        "value" : [ " union " ]
-                     }, {
-                        "r" : "3381",
-                        "s" : [ {
-                           "value" : [ "FlexSigObservations" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "3391",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "3392",
-                  "name" : "{http://hl7.org/fhir}Observation",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "3384",
-               "locator" : "529:3-529:137",
-               "type" : "Union",
-               "resultTypeSpecifier" : {
-                  "localId" : "3389",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3390",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "signature" : [ {
-                  "localId" : "3385",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3386",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               }, {
-                  "localId" : "3387",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "3388",
-                     "name" : "{http://hl7.org/fhir}Observation",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "operand" : [ {
-                  "localId" : "3340",
-                  "locator" : "529:3-529:111",
-                  "type" : "Union",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3345",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3346",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "signature" : [ {
-                     "localId" : "3341",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3342",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }, {
-                     "localId" : "3343",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3344",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  } ],
-                  "operand" : [ {
-                     "localId" : "3301",
-                     "locator" : "529:3-529:48",
-                     "type" : "Union",
-                     "resultTypeSpecifier" : {
-                        "localId" : "3306",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "3307",
-                           "name" : "{http://hl7.org/fhir}Observation",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     },
-                     "signature" : [ {
-                        "localId" : "3302",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "3303",
-                           "name" : "{http://hl7.org/fhir}Observation",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }, {
-                        "localId" : "3304",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "3305",
-                           "name" : "{http://hl7.org/fhir}Observation",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     } ],
-                     "operand" : [ {
-                        "localId" : "3281",
-                        "locator" : "529:3-529:18",
-                        "name" : "FOBTObservations",
-                        "type" : "ExpressionRef",
-                        "resultTypeSpecifier" : {
-                           "localId" : "3282",
-                           "type" : "ListTypeSpecifier",
-                           "elementType" : {
-                              "localId" : "3283",
-                              "name" : "{http://hl7.org/fhir}Observation",
-                              "type" : "NamedTypeSpecifier"
-                           }
-                        }
-                     }, {
-                        "localId" : "3298",
-                        "locator" : "529:26-529:48",
-                        "name" : "StoolDNAFITObservations",
-                        "type" : "ExpressionRef",
-                        "resultTypeSpecifier" : {
-                           "localId" : "3299",
-                           "type" : "ListTypeSpecifier",
-                           "elementType" : {
-                              "localId" : "3300",
-                              "name" : "{http://hl7.org/fhir}Observation",
-                              "type" : "NamedTypeSpecifier"
-                           }
-                        }
-                     } ]
-                  }, {
-                     "localId" : "3335",
-                     "type" : "Union",
-                     "signature" : [ {
-                        "localId" : "3336",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "3337",
-                           "name" : "{http://hl7.org/fhir}Observation",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }, {
-                        "localId" : "3338",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "3339",
-                           "name" : "{http://hl7.org/fhir}Observation",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     } ],
-                     "operand" : [ {
-                        "localId" : "3308",
-                        "locator" : "529:56-529:78",
-                        "name" : "ColonoscopyObservations",
-                        "type" : "ExpressionRef",
-                        "resultTypeSpecifier" : {
-                           "localId" : "3309",
-                           "type" : "ListTypeSpecifier",
-                           "elementType" : {
-                              "localId" : "3310",
-                              "name" : "{http://hl7.org/fhir}Observation",
-                              "type" : "NamedTypeSpecifier"
-                           }
-                        }
-                     }, {
-                        "localId" : "3332",
-                        "locator" : "529:86-529:111",
-                        "name" : "CTColonographyObservations",
-                        "type" : "ExpressionRef",
-                        "resultTypeSpecifier" : {
-                           "localId" : "3333",
-                           "type" : "ListTypeSpecifier",
-                           "elementType" : {
-                              "localId" : "3334",
-                              "name" : "{http://hl7.org/fhir}Observation",
-                              "type" : "NamedTypeSpecifier"
-                           }
-                        }
-                     } ]
-                  } ]
-               }, {
-                  "localId" : "3381",
-                  "locator" : "529:119-529:137",
-                  "name" : "FlexSigObservations",
-                  "type" : "ExpressionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "3382",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "3383",
-                        "name" : "{http://hl7.org/fhir}Observation",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }
-               } ]
-            }
-         }, {
-            "localId" : "3400",
-            "locator" : "540:1-541:103",
+            "localId" : "3469",
+            "locator" : "570:1-572:44",
             "name" : "FOBTDiagnosticReports",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3400",
+                  "r" : "3469",
                   "s" : [ {
                      "value" : [ "","define ","FOBTDiagnosticReports",":\n  " ]
                   }, {
-                     "r" : "3404",
+                     "r" : "3483",
                      "s" : [ {
-                        "r" : "3401",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3470",
+                           "s" : [ {
+                              "r" : "3471",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningDiagnosticReports" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","R" ]
+                           } ]
                         } ]
                      }, {
-                        "value" : [ "." ]
+                        "value" : [ "\n   " ]
                      }, {
-                        "r" : "3404",
+                        "r" : "3479",
                         "s" : [ {
-                           "value" : [ "CompletedDiagnosticReportsByLookback","(" ]
+                           "value" : [ "where " ]
                         }, {
-                           "r" : "3402",
+                           "r" : "3479",
                            "s" : [ {
-                              "value" : [ "\"Fecal Occult Blood Test\"" ]
+                              "r" : "3477",
+                              "s" : [ {
+                                 "r" : "3476",
+                                 "s" : [ {
+                                    "value" : [ "R" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3477",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3478",
+                              "s" : [ {
+                                 "value" : [ "\"Fecal Occult Blood Test\"" ]
+                              } ]
                            } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3403",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
                         } ]
                      } ]
                   } ]
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3446",
+               "localId" : "3541",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3447",
+                  "localId" : "3542",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3404",
-               "locator" : "541:3-541:103",
-               "name" : "CompletedDiagnosticReportsByLookback",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
+               "localId" : "3483",
+               "locator" : "571:3-572:44",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3409",
+                  "localId" : "3484",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3410",
+                     "localId" : "3485",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3405",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3406",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3470",
+                  "locator" : "571:3-571:46",
+                  "alias" : "R",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3474",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3475",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3471",
+                     "locator" : "571:3-571:44",
+                     "name" : "ColorectalCancerScreeningDiagnosticReports",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3472",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3473",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
                } ],
-               "operand" : [ {
-                  "localId" : "3402",
-                  "locator" : "541:52-541:76",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Fecal Occult Blood Test",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3403",
-                  "locator" : "541:79-541:102",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3479",
+                  "locator" : "572:4-572:44",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3482",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3480",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3481",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3477",
+                        "locator" : "572:10-572:15",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "R",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3478",
+                     "locator" : "572:20-572:44",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Fecal Occult Blood Test",
+                     "preserve" : true
+                  }
+               }
             }
          }, {
-            "localId" : "3397",
-            "locator" : "535:1-538:66",
+            "localId" : "3497",
+            "locator" : "574:1-576:45",
+            "name" : "FOBTObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3497",
+                  "s" : [ {
+                     "value" : [ "","define ","FOBTObservations",":\n  " ]
+                  }, {
+                     "r" : "3511",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "3498",
+                           "s" : [ {
+                              "r" : "3499",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","O" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "3507",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "3507",
+                           "s" : [ {
+                              "r" : "3505",
+                              "s" : [ {
+                                 "r" : "3504",
+                                 "s" : [ {
+                                    "value" : [ "O" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3505",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3506",
+                              "s" : [ {
+                                 "value" : [ "\"Fecal Occult Blood Test\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3543",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3544",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3511",
+               "locator" : "575:3-576:45",
+               "type" : "Query",
+               "resultTypeSpecifier" : {
+                  "localId" : "3512",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3513",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "source" : [ {
+                  "localId" : "3498",
+                  "locator" : "575:3-575:41",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3502",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3503",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3499",
+                     "locator" : "575:3-575:39",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3500",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3501",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               } ],
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3507",
+                  "locator" : "576:5-576:45",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3510",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3508",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3509",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3505",
+                        "locator" : "576:11-576:16",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "O",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3506",
+                     "locator" : "576:21-576:45",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Fecal Occult Blood Test",
+                     "preserve" : true
+                  }
+               }
+            }
+         }, {
+            "localId" : "3466",
+            "locator" : "565:1-568:66",
             "name" : "FOBTDiagnosticReportsWithResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3397",
+                  "r" : "3466",
                   "s" : [ {
                      "value" : [ "","define ","FOBTDiagnosticReportsWithResults",":\n  " ]
                   }, {
-                     "r" : "3434",
+                     "r" : "3529",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3398",
+                           "r" : "3467",
                            "s" : [ {
-                              "r" : "3413",
+                              "r" : "3488",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "FOBTDiagnosticReports" ]
@@ -30284,35 +31156,35 @@
                      }, {
                         "value" : [ "\n  " ]
                      }, {
-                        "r" : "3418",
+                        "r" : "3493",
                         "s" : [ {
                            "value" : [ "where\n    " ]
                         }, {
-                           "r" : "3418",
+                           "r" : "3493",
                            "s" : [ {
                               "value" : [ "exists " ]
                            }, {
-                              "r" : "3424",
+                              "r" : "3519",
                               "s" : [ {
-                                 "r" : "3419",
+                                 "r" : "3494",
                                  "s" : [ {
                                     "value" : [ "CRCSMCommon" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "3424",
+                                 "r" : "3519",
                                  "s" : [ {
                                     "value" : [ "CollateConclusionCodes","(" ]
                                  }, {
-                                    "r" : "3420",
+                                    "r" : "3495",
                                     "s" : [ {
                                        "value" : [ "D" ]
                                     } ]
                                  }, {
                                     "value" : [ ", " ]
                                  }, {
-                                    "r" : "3421",
+                                    "r" : "3516",
                                     "s" : [ {
                                        "value" : [ "FOBTObservations" ]
                                     } ]
@@ -30327,50 +31199,50 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3444",
+               "localId" : "3539",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3445",
+                  "localId" : "3540",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3434",
-               "locator" : "536:3-538:66",
+               "localId" : "3529",
+               "locator" : "566:3-568:66",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3435",
+                  "localId" : "3530",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3436",
+                     "localId" : "3531",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
-                  "localId" : "3398",
-                  "locator" : "536:3-536:25",
+                  "localId" : "3467",
+                  "locator" : "566:3-566:25",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3416",
+                     "localId" : "3491",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3417",
+                        "localId" : "3492",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3413",
-                     "locator" : "536:3-536:23",
+                     "localId" : "3488",
+                     "locator" : "566:3-566:23",
                      "name" : "FOBTDiagnosticReports",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3414",
+                        "localId" : "3489",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3415",
+                           "localId" : "3490",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -30380,63 +31252,63 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3418",
-                  "locator" : "537:3-538:66",
+                  "localId" : "3493",
+                  "locator" : "567:3-568:66",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Exists",
                   "signature" : [ {
-                     "localId" : "3432",
+                     "localId" : "3527",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3433",
+                        "localId" : "3528",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "3424",
-                     "locator" : "538:12-538:66",
+                     "localId" : "3519",
+                     "locator" : "568:12-568:66",
                      "name" : "CollateConclusionCodes",
                      "libraryName" : "CRCSMCommon",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3430",
+                        "localId" : "3525",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3431",
+                           "localId" : "3526",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3425",
+                        "localId" : "3520",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "3426",
+                        "localId" : "3521",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3427",
+                           "localId" : "3522",
                            "name" : "{http://hl7.org/fhir}Observation",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3420",
-                        "locator" : "538:47",
+                        "localId" : "3495",
+                        "locator" : "568:47",
                         "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                         "name" : "D",
                         "type" : "AliasRef"
                      }, {
-                        "localId" : "3421",
-                        "locator" : "538:50-538:65",
+                        "localId" : "3516",
+                        "locator" : "568:50-568:65",
                         "name" : "FOBTObservations",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3422",
+                           "localId" : "3517",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3423",
+                              "localId" : "3518",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -30446,8 +31318,8 @@
                }
             }
          }, {
-            "localId" : "3394",
-            "locator" : "532:1-533:41",
+            "localId" : "3463",
+            "locator" : "562:1-563:41",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-FOBT",
             "context" : "Patient",
@@ -30455,15 +31327,15 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3394",
+                  "r" : "3463",
                   "s" : [ {
                      "value" : [ "//FOBT (includes FIT and gFOBT)\n","define ","\"de-FOBT\"",":\n  " ]
                   }, {
-                     "r" : "3395",
+                     "r" : "3464",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "3439",
+                        "r" : "3534",
                         "s" : [ {
                            "value" : [ "FOBTDiagnosticReportsWithResults" ]
                         } ]
@@ -30472,29 +31344,29 @@
                }
             } ],
             "expression" : {
-               "localId" : "3395",
-               "locator" : "533:3-533:41",
+               "localId" : "3464",
+               "locator" : "563:3-563:41",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "3442",
+                  "localId" : "3537",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3443",
+                     "localId" : "3538",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "3439",
-                  "locator" : "533:10-533:41",
+                  "localId" : "3534",
+                  "locator" : "563:10-563:41",
                   "name" : "FOBTDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3440",
+                     "localId" : "3535",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3441",
+                        "localId" : "3536",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -30502,116 +31374,334 @@
                }
             }
          }, {
-            "localId" : "3457",
-            "locator" : "555:1-556:93",
+            "localId" : "3552",
+            "locator" : "587:1-589:34",
             "name" : "StoolDNAFITDiagnosticReports",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3457",
+                  "r" : "3552",
                   "s" : [ {
                      "value" : [ "","define ","StoolDNAFITDiagnosticReports",":\n  " ]
                   }, {
-                     "r" : "3461",
+                     "r" : "3566",
                      "s" : [ {
-                        "r" : "3458",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3553",
+                           "s" : [ {
+                              "r" : "3554",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningDiagnosticReports" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","R" ]
+                           } ]
                         } ]
                      }, {
-                        "value" : [ "." ]
+                        "value" : [ "\n   " ]
                      }, {
-                        "r" : "3461",
+                        "r" : "3562",
                         "s" : [ {
-                           "value" : [ "CompletedDiagnosticReportsByLookback","(" ]
+                           "value" : [ "where " ]
                         }, {
-                           "r" : "3459",
+                           "r" : "3562",
                            "s" : [ {
-                              "value" : [ "\"Stool DNA-FIT\"" ]
+                              "r" : "3560",
+                              "s" : [ {
+                                 "r" : "3559",
+                                 "s" : [ {
+                                    "value" : [ "R" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3560",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3561",
+                              "s" : [ {
+                                 "value" : [ "\"Stool DNA-FIT\"" ]
+                              } ]
                            } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3460",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
                         } ]
                      } ]
                   } ]
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3503",
+               "localId" : "3624",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3504",
+                  "localId" : "3625",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3461",
-               "locator" : "556:3-556:93",
-               "name" : "CompletedDiagnosticReportsByLookback",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
+               "localId" : "3566",
+               "locator" : "588:3-589:34",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3466",
+                  "localId" : "3567",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3467",
+                     "localId" : "3568",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3462",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3463",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3553",
+                  "locator" : "588:3-588:46",
+                  "alias" : "R",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3557",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3558",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3554",
+                     "locator" : "588:3-588:44",
+                     "name" : "ColorectalCancerScreeningDiagnosticReports",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3555",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3556",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
                } ],
-               "operand" : [ {
-                  "localId" : "3459",
-                  "locator" : "556:52-556:66",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Stool DNA-FIT",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3460",
-                  "locator" : "556:69-556:92",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3562",
+                  "locator" : "589:4-589:34",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3565",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3563",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3564",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3560",
+                        "locator" : "589:10-589:15",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "R",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3561",
+                     "locator" : "589:20-589:34",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Stool DNA-FIT",
+                     "preserve" : true
+                  }
+               }
             }
          }, {
-            "localId" : "3454",
-            "locator" : "550:1-553:75",
+            "localId" : "3580",
+            "locator" : "591:1-593:35",
+            "name" : "StoolDNAFITObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3580",
+                  "s" : [ {
+                     "value" : [ "","define ","StoolDNAFITObservations",":\n  " ]
+                  }, {
+                     "r" : "3594",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "3581",
+                           "s" : [ {
+                              "r" : "3582",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","O" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "3590",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "3590",
+                           "s" : [ {
+                              "r" : "3588",
+                              "s" : [ {
+                                 "r" : "3587",
+                                 "s" : [ {
+                                    "value" : [ "O" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3588",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3589",
+                              "s" : [ {
+                                 "value" : [ "\"Stool DNA-FIT\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3626",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3627",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3594",
+               "locator" : "592:3-593:35",
+               "type" : "Query",
+               "resultTypeSpecifier" : {
+                  "localId" : "3595",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3596",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "source" : [ {
+                  "localId" : "3581",
+                  "locator" : "592:3-592:41",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3585",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3586",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3582",
+                     "locator" : "592:3-592:39",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3583",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3584",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               } ],
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3590",
+                  "locator" : "593:5-593:35",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3593",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3591",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3592",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3588",
+                        "locator" : "593:11-593:16",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "O",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3589",
+                     "locator" : "593:21-593:35",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Stool DNA-FIT",
+                     "preserve" : true
+                  }
+               }
+            }
+         }, {
+            "localId" : "3549",
+            "locator" : "582:1-585:75",
             "name" : "StoolDNAFITDiagnosticReportsWithResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3454",
+                  "r" : "3549",
                   "s" : [ {
                      "value" : [ "","define ","StoolDNAFITDiagnosticReportsWithResults",":\n   " ]
                   }, {
-                     "r" : "3491",
+                     "r" : "3612",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3455",
+                           "r" : "3550",
                            "s" : [ {
-                              "r" : "3470",
+                              "r" : "3571",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "StoolDNAFITDiagnosticReports" ]
@@ -30624,35 +31714,35 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3475",
+                        "r" : "3576",
                         "s" : [ {
                            "value" : [ "where\n      " ]
                         }, {
-                           "r" : "3475",
+                           "r" : "3576",
                            "s" : [ {
                               "value" : [ "exists " ]
                            }, {
-                              "r" : "3481",
+                              "r" : "3602",
                               "s" : [ {
-                                 "r" : "3476",
+                                 "r" : "3577",
                                  "s" : [ {
                                     "value" : [ "CRCSMCommon" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "3481",
+                                 "r" : "3602",
                                  "s" : [ {
                                     "value" : [ "CollateConclusionCodes","(" ]
                                  }, {
-                                    "r" : "3477",
+                                    "r" : "3578",
                                     "s" : [ {
                                        "value" : [ "D" ]
                                     } ]
                                  }, {
                                     "value" : [ ", " ]
                                  }, {
-                                    "r" : "3478",
+                                    "r" : "3599",
                                     "s" : [ {
                                        "value" : [ "StoolDNAFITObservations" ]
                                     } ]
@@ -30667,50 +31757,50 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3501",
+               "localId" : "3622",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3502",
+                  "localId" : "3623",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3491",
-               "locator" : "551:4-553:75",
+               "localId" : "3612",
+               "locator" : "583:4-585:75",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3492",
+                  "localId" : "3613",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3493",
+                     "localId" : "3614",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
-                  "localId" : "3455",
-                  "locator" : "551:4-551:33",
+                  "localId" : "3550",
+                  "locator" : "583:4-583:33",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3473",
+                     "localId" : "3574",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3474",
+                        "localId" : "3575",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3470",
-                     "locator" : "551:4-551:31",
+                     "localId" : "3571",
+                     "locator" : "583:4-583:31",
                      "name" : "StoolDNAFITDiagnosticReports",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3471",
+                        "localId" : "3572",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3472",
+                           "localId" : "3573",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -30720,63 +31810,63 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3475",
-                  "locator" : "552:5-553:75",
+                  "localId" : "3576",
+                  "locator" : "584:5-585:75",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Exists",
                   "signature" : [ {
-                     "localId" : "3489",
+                     "localId" : "3610",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3490",
+                        "localId" : "3611",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "3481",
-                     "locator" : "553:14-553:75",
+                     "localId" : "3602",
+                     "locator" : "585:14-585:75",
                      "name" : "CollateConclusionCodes",
                      "libraryName" : "CRCSMCommon",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3487",
+                        "localId" : "3608",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3488",
+                           "localId" : "3609",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3482",
+                        "localId" : "3603",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "3483",
+                        "localId" : "3604",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3484",
+                           "localId" : "3605",
                            "name" : "{http://hl7.org/fhir}Observation",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3477",
-                        "locator" : "553:49",
+                        "localId" : "3578",
+                        "locator" : "585:49",
                         "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                         "name" : "D",
                         "type" : "AliasRef"
                      }, {
-                        "localId" : "3478",
-                        "locator" : "553:52-553:74",
+                        "localId" : "3599",
+                        "locator" : "585:52-585:74",
                         "name" : "StoolDNAFITObservations",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3479",
+                           "localId" : "3600",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3480",
+                              "localId" : "3601",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -30786,8 +31876,8 @@
                }
             }
          }, {
-            "localId" : "3451",
-            "locator" : "547:1-548:50",
+            "localId" : "3546",
+            "locator" : "579:1-580:50",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-stoolDNAFIT",
             "context" : "Patient",
@@ -30795,15 +31885,15 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3451",
+                  "r" : "3546",
                   "s" : [ {
                      "value" : [ "// Stool DNA-FIT\n","define ","\"de-stoolDNAFIT\"",":\n    " ]
                   }, {
-                     "r" : "3452",
+                     "r" : "3547",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "3496",
+                        "r" : "3617",
                         "s" : [ {
                            "value" : [ "StoolDNAFITDiagnosticReportsWithResults" ]
                         } ]
@@ -30812,29 +31902,29 @@
                }
             } ],
             "expression" : {
-               "localId" : "3452",
-               "locator" : "548:5-548:50",
+               "localId" : "3547",
+               "locator" : "580:5-580:50",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "3499",
+                  "localId" : "3620",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3500",
+                     "localId" : "3621",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "3496",
-                  "locator" : "548:12-548:50",
+                  "localId" : "3617",
+                  "locator" : "580:12-580:50",
                   "name" : "StoolDNAFITDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3497",
+                     "localId" : "3618",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3498",
+                        "localId" : "3619",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -30842,8 +31932,8 @@
                }
             }
          }, {
-            "localId" : "3508",
-            "locator" : "562:1-563:48",
+            "localId" : "3629",
+            "locator" : "596:1-597:48",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-Colonoscopy",
             "context" : "Patient",
@@ -30851,15 +31941,15 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3508",
+                  "r" : "3629",
                   "s" : [ {
                      "value" : [ "// Colonoscopy\n","define ","\"de-Colonoscopy\"",": \n  " ]
                   }, {
-                     "r" : "3509",
+                     "r" : "3630",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "3510",
+                        "r" : "3631",
                         "s" : [ {
                            "value" : [ "ColonoscopyDiagnosticReportsWithResults" ]
                         } ]
@@ -30868,29 +31958,29 @@
                }
             } ],
             "expression" : {
-               "localId" : "3509",
-               "locator" : "563:3-563:48",
+               "localId" : "3630",
+               "locator" : "597:3-597:48",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "3513",
+                  "localId" : "3634",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3514",
+                     "localId" : "3635",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "3510",
-                  "locator" : "563:10-563:48",
+                  "localId" : "3631",
+                  "locator" : "597:10-597:48",
                   "name" : "ColonoscopyDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3511",
+                     "localId" : "3632",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3512",
+                        "localId" : "3633",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -30898,116 +31988,334 @@
                }
             }
          }, {
-            "localId" : "3528",
-            "locator" : "588:1-589:101",
+            "localId" : "3649",
+            "locator" : "623:1-625:42",
             "name" : "CTColonographyDiagnosticReports",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3528",
+                  "r" : "3649",
                   "s" : [ {
                      "value" : [ "","define ","CTColonographyDiagnosticReports",":\n  " ]
                   }, {
-                     "r" : "3532",
+                     "r" : "3663",
                      "s" : [ {
-                        "r" : "3529",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3650",
+                           "s" : [ {
+                              "r" : "3651",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningDiagnosticReports" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","R" ]
+                           } ]
                         } ]
                      }, {
-                        "value" : [ "." ]
+                        "value" : [ "\n   " ]
                      }, {
-                        "r" : "3532",
+                        "r" : "3659",
                         "s" : [ {
-                           "value" : [ "CompletedDiagnosticReportsByLookback","(" ]
+                           "value" : [ "where " ]
                         }, {
-                           "r" : "3530",
+                           "r" : "3659",
                            "s" : [ {
-                              "value" : [ "\"CT Colonography Study\"" ]
+                              "r" : "3657",
+                              "s" : [ {
+                                 "r" : "3656",
+                                 "s" : [ {
+                                    "value" : [ "R" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3657",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3658",
+                              "s" : [ {
+                                 "value" : [ "\"CT Colonography Study\"" ]
+                              } ]
                            } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3531",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
                         } ]
                      } ]
                   } ]
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3574",
+               "localId" : "3721",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3575",
+                  "localId" : "3722",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3532",
-               "locator" : "589:3-589:101",
-               "name" : "CompletedDiagnosticReportsByLookback",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
+               "localId" : "3663",
+               "locator" : "624:3-625:42",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3537",
+                  "localId" : "3664",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3538",
+                     "localId" : "3665",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3533",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3534",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3650",
+                  "locator" : "624:3-624:46",
+                  "alias" : "R",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3654",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3655",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3651",
+                     "locator" : "624:3-624:44",
+                     "name" : "ColorectalCancerScreeningDiagnosticReports",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3652",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3653",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
                } ],
-               "operand" : [ {
-                  "localId" : "3530",
-                  "locator" : "589:52-589:74",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "CT Colonography Study",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3531",
-                  "locator" : "589:77-589:100",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3659",
+                  "locator" : "625:4-625:42",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3662",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3660",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3661",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3657",
+                        "locator" : "625:10-625:15",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "R",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3658",
+                     "locator" : "625:20-625:42",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "CT Colonography Study",
+                     "preserve" : true
+                  }
+               }
             }
          }, {
-            "localId" : "3525",
-            "locator" : "583:1-586:78",
+            "localId" : "3677",
+            "locator" : "627:1-629:43",
+            "name" : "CTColonographyObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3677",
+                  "s" : [ {
+                     "value" : [ "","define ","CTColonographyObservations",":\n  " ]
+                  }, {
+                     "r" : "3691",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "3678",
+                           "s" : [ {
+                              "r" : "3679",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","O" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "3687",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "3687",
+                           "s" : [ {
+                              "r" : "3685",
+                              "s" : [ {
+                                 "r" : "3684",
+                                 "s" : [ {
+                                    "value" : [ "O" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3685",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3686",
+                              "s" : [ {
+                                 "value" : [ "\"CT Colonography Study\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3723",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3724",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3691",
+               "locator" : "628:3-629:43",
+               "type" : "Query",
+               "resultTypeSpecifier" : {
+                  "localId" : "3692",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3693",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "source" : [ {
+                  "localId" : "3678",
+                  "locator" : "628:3-628:41",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3682",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3683",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3679",
+                     "locator" : "628:3-628:39",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3680",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3681",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               } ],
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3687",
+                  "locator" : "629:5-629:43",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3690",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3688",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3689",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3685",
+                        "locator" : "629:11-629:16",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "O",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3686",
+                     "locator" : "629:21-629:43",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "CT Colonography Study",
+                     "preserve" : true
+                  }
+               }
+            }
+         }, {
+            "localId" : "3646",
+            "locator" : "618:1-621:78",
             "name" : "CTColonographyDiagnosticReportsWithResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3525",
+                  "r" : "3646",
                   "s" : [ {
                      "value" : [ "","define ","CTColonographyDiagnosticReportsWithResults",":\n  " ]
                   }, {
-                     "r" : "3562",
+                     "r" : "3709",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3526",
+                           "r" : "3647",
                            "s" : [ {
-                              "r" : "3541",
+                              "r" : "3668",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "CTColonographyDiagnosticReports" ]
@@ -31020,35 +32328,35 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3546",
+                        "r" : "3673",
                         "s" : [ {
                            "value" : [ "where\n      " ]
                         }, {
-                           "r" : "3546",
+                           "r" : "3673",
                            "s" : [ {
                               "value" : [ "exists " ]
                            }, {
-                              "r" : "3552",
+                              "r" : "3699",
                               "s" : [ {
-                                 "r" : "3547",
+                                 "r" : "3674",
                                  "s" : [ {
                                     "value" : [ "CRCSMCommon" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "3552",
+                                 "r" : "3699",
                                  "s" : [ {
                                     "value" : [ "CollateConclusionCodes","(" ]
                                  }, {
-                                    "r" : "3548",
+                                    "r" : "3675",
                                     "s" : [ {
                                        "value" : [ "D" ]
                                     } ]
                                  }, {
                                     "value" : [ ", " ]
                                  }, {
-                                    "r" : "3549",
+                                    "r" : "3696",
                                     "s" : [ {
                                        "value" : [ "CTColonographyObservations" ]
                                     } ]
@@ -31063,50 +32371,50 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3572",
+               "localId" : "3719",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3573",
+                  "localId" : "3720",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3562",
-               "locator" : "584:3-586:78",
+               "localId" : "3709",
+               "locator" : "619:3-621:78",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3563",
+                  "localId" : "3710",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3564",
+                     "localId" : "3711",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
-                  "localId" : "3526",
-                  "locator" : "584:3-584:35",
+                  "localId" : "3647",
+                  "locator" : "619:3-619:35",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3544",
+                     "localId" : "3671",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3545",
+                        "localId" : "3672",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3541",
-                     "locator" : "584:3-584:33",
+                     "localId" : "3668",
+                     "locator" : "619:3-619:33",
                      "name" : "CTColonographyDiagnosticReports",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3542",
+                        "localId" : "3669",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3543",
+                           "localId" : "3670",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -31116,63 +32424,63 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3546",
-                  "locator" : "585:5-586:78",
+                  "localId" : "3673",
+                  "locator" : "620:5-621:78",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Exists",
                   "signature" : [ {
-                     "localId" : "3560",
+                     "localId" : "3707",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3561",
+                        "localId" : "3708",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "3552",
-                     "locator" : "586:14-586:78",
+                     "localId" : "3699",
+                     "locator" : "621:14-621:78",
                      "name" : "CollateConclusionCodes",
                      "libraryName" : "CRCSMCommon",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3558",
+                        "localId" : "3705",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3559",
+                           "localId" : "3706",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3553",
+                        "localId" : "3700",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "3554",
+                        "localId" : "3701",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3555",
+                           "localId" : "3702",
                            "name" : "{http://hl7.org/fhir}Observation",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3548",
-                        "locator" : "586:49",
+                        "localId" : "3675",
+                        "locator" : "621:49",
                         "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                         "name" : "D",
                         "type" : "AliasRef"
                      }, {
-                        "localId" : "3549",
-                        "locator" : "586:52-586:77",
+                        "localId" : "3696",
+                        "locator" : "621:52-621:77",
                         "name" : "CTColonographyObservations",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3550",
+                           "localId" : "3697",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3551",
+                              "localId" : "3698",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -31182,8 +32490,8 @@
                }
             }
          }, {
-            "localId" : "3522",
-            "locator" : "580:1-581:51",
+            "localId" : "3643",
+            "locator" : "615:1-616:51",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-CTColonography",
             "context" : "Patient",
@@ -31191,15 +32499,15 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3522",
+                  "r" : "3643",
                   "s" : [ {
                      "value" : [ "// CT Colonography\n","define ","\"de-CTColonography\"",":\n  " ]
                   }, {
-                     "r" : "3523",
+                     "r" : "3644",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "3567",
+                        "r" : "3714",
                         "s" : [ {
                            "value" : [ "CTColonographyDiagnosticReportsWithResults" ]
                         } ]
@@ -31208,29 +32516,29 @@
                }
             } ],
             "expression" : {
-               "localId" : "3523",
-               "locator" : "581:3-581:51",
+               "localId" : "3644",
+               "locator" : "616:3-616:51",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "3570",
+                  "localId" : "3717",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3571",
+                     "localId" : "3718",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "3567",
-                  "locator" : "581:10-581:51",
+                  "localId" : "3714",
+                  "locator" : "616:10-616:51",
                   "name" : "CTColonographyDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3568",
+                     "localId" : "3715",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3569",
+                        "localId" : "3716",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -31238,116 +32546,427 @@
                }
             }
          }, {
-            "localId" : "3585",
-            "locator" : "604:1-605:108",
+            "localId" : "3732",
+            "locator" : "641:1-643:49",
             "name" : "FlexSigDiagnosticReports",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3585",
+                  "r" : "3732",
                   "s" : [ {
                      "value" : [ "","define ","FlexSigDiagnosticReports",":\n  " ]
                   }, {
-                     "r" : "3589",
+                     "r" : "3746",
                      "s" : [ {
-                        "r" : "3586",
                         "s" : [ {
-                           "value" : [ "CRCSMCommon" ]
+                           "r" : "3733",
+                           "s" : [ {
+                              "r" : "3734",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningDiagnosticReports" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","R" ]
+                           } ]
                         } ]
                      }, {
-                        "value" : [ "." ]
+                        "value" : [ "\n   " ]
                      }, {
-                        "r" : "3589",
+                        "r" : "3742",
                         "s" : [ {
-                           "value" : [ "CompletedDiagnosticReportsByLookback","(" ]
+                           "value" : [ "where " ]
                         }, {
-                           "r" : "3587",
+                           "r" : "3742",
                            "s" : [ {
-                              "value" : [ "\"Flexible Sigmoidoscopy Study\"" ]
+                              "r" : "3740",
+                              "s" : [ {
+                                 "r" : "3739",
+                                 "s" : [ {
+                                    "value" : [ "R" ]
+                                 } ]
+                              }, {
+                                 "value" : [ "." ]
+                              }, {
+                                 "r" : "3740",
+                                 "s" : [ {
+                                    "value" : [ "code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " in " ]
+                           }, {
+                              "r" : "3741",
+                              "s" : [ {
+                                 "value" : [ "\"Flexible Sigmoidoscopy Study\"" ]
+                              } ]
                            } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "3588",
-                           "s" : [ {
-                              "value" : [ "ScreeningHistoryLookback" ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
                         } ]
                      } ]
                   } ]
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3650",
+               "localId" : "3837",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3651",
+                  "localId" : "3838",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3589",
-               "locator" : "605:3-605:108",
-               "name" : "CompletedDiagnosticReportsByLookback",
-               "libraryName" : "CRCSMCommon",
-               "type" : "FunctionRef",
+               "localId" : "3746",
+               "locator" : "642:3-643:49",
+               "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3594",
+                  "localId" : "3747",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3595",
+                     "localId" : "3748",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
-               "signature" : [ {
-                  "localId" : "3590",
-                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "type" : "NamedTypeSpecifier"
-               }, {
-                  "localId" : "3591",
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
+               "source" : [ {
+                  "localId" : "3733",
+                  "locator" : "642:3-642:46",
+                  "alias" : "R",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3737",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3738",
+                        "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3734",
+                     "locator" : "642:3-642:44",
+                     "name" : "ColorectalCancerScreeningDiagnosticReports",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3735",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3736",
+                           "name" : "{http://hl7.org/fhir}DiagnosticReport",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
                } ],
-               "operand" : [ {
-                  "localId" : "3587",
-                  "locator" : "605:52-605:81",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Flexible Sigmoidoscopy Study",
-                  "preserve" : true,
-                  "type" : "ValueSetRef"
-               }, {
-                  "localId" : "3588",
-                  "locator" : "605:84-605:107",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "name" : "ScreeningHistoryLookback",
-                  "type" : "ParameterRef"
-               } ]
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3742",
+                  "locator" : "643:4-643:49",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "InValueSet",
+                  "signature" : [ {
+                     "localId" : "3745",
+                     "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "code" : {
+                     "localId" : "3743",
+                     "name" : "ToConcept",
+                     "libraryName" : "FHIRHelpers",
+                     "type" : "FunctionRef",
+                     "signature" : [ {
+                        "localId" : "3744",
+                        "name" : "{http://hl7.org/fhir}CodeableConcept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3740",
+                        "locator" : "643:10-643:15",
+                        "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                        "path" : "code",
+                        "scope" : "R",
+                        "type" : "Property"
+                     } ]
+                  },
+                  "valueset" : {
+                     "localId" : "3741",
+                     "locator" : "643:20-643:49",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "Flexible Sigmoidoscopy Study",
+                     "preserve" : true
+                  }
+               }
             }
          }, {
-            "localId" : "3582",
-            "locator" : "598:1-602:77",
+            "localId" : "3761",
+            "locator" : "645:1-648:60",
+            "name" : "FlexSigObservations",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3761",
+                  "s" : [ {
+                     "value" : [ "","define ","FlexSigObservations",":\n" ]
+                  }, {
+                     "r" : "3789",
+                     "s" : [ {
+                        "s" : [ {
+                           "r" : "3762",
+                           "s" : [ {
+                              "r" : "3763",
+                              "s" : [ {
+                                 "s" : [ {
+                                    "value" : [ "ColorectalCancerScreeningObservations" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " ","O" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n    " ]
+                     }, {
+                        "r" : "3768",
+                        "s" : [ {
+                           "value" : [ "where " ]
+                        }, {
+                           "r" : "3768",
+                           "s" : [ {
+                              "r" : "3772",
+                              "s" : [ {
+                                 "r" : "3770",
+                                 "s" : [ {
+                                    "r" : "3769",
+                                    "s" : [ {
+                                       "value" : [ "O" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "3770",
+                                    "s" : [ {
+                                       "value" : [ "code" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ " in " ]
+                              }, {
+                                 "r" : "3771",
+                                 "s" : [ {
+                                    "value" : [ "\"Flexible Sigmoidoscopy Study\"" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "\n      or " ]
+                           }, {
+                              "r" : "3776",
+                              "s" : [ {
+                                 "r" : "3778",
+                                 "s" : [ {
+                                    "r" : "3777",
+                                    "s" : [ {
+                                       "value" : [ "O" ]
+                                    } ]
+                                 }, {
+                                    "value" : [ "." ]
+                                 }, {
+                                    "r" : "3778",
+                                    "s" : [ {
+                                       "value" : [ "code" ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ " ","~"," " ]
+                              }, {
+                                 "r" : "3779",
+                                 "s" : [ {
+                                    "value" : [ "\"Flexible Sigmoidoscopy Study Observation\"" ]
+                                 } ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "3839",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "3840",
+                  "name" : "{http://hl7.org/fhir}Observation",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "3789",
+               "locator" : "646:1-648:60",
+               "type" : "Query",
+               "resultTypeSpecifier" : {
+                  "localId" : "3790",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "3791",
+                     "name" : "{http://hl7.org/fhir}Observation",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "source" : [ {
+                  "localId" : "3762",
+                  "locator" : "646:1-646:39",
+                  "alias" : "O",
+                  "resultTypeSpecifier" : {
+                     "localId" : "3766",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "3767",
+                        "name" : "{http://hl7.org/fhir}Observation",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "expression" : {
+                     "localId" : "3763",
+                     "locator" : "646:1-646:37",
+                     "name" : "ColorectalCancerScreeningObservations",
+                     "type" : "ExpressionRef",
+                     "resultTypeSpecifier" : {
+                        "localId" : "3764",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "3765",
+                           "name" : "{http://hl7.org/fhir}Observation",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               } ],
+               "let" : [ ],
+               "relationship" : [ ],
+               "where" : {
+                  "localId" : "3768",
+                  "locator" : "647:5-648:60",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Or",
+                  "signature" : [ {
+                     "localId" : "3787",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "3788",
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "operand" : [ {
+                     "localId" : "3772",
+                     "locator" : "647:11-647:50",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "InValueSet",
+                     "signature" : [ {
+                        "localId" : "3775",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "code" : {
+                        "localId" : "3773",
+                        "name" : "ToConcept",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "signature" : [ {
+                           "localId" : "3774",
+                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3770",
+                           "locator" : "647:11-647:16",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "code",
+                           "scope" : "O",
+                           "type" : "Property"
+                        } ]
+                     },
+                     "valueset" : {
+                        "localId" : "3771",
+                        "locator" : "647:21-647:50",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "name" : "Flexible Sigmoidoscopy Study",
+                        "preserve" : true
+                     }
+                  }, {
+                     "localId" : "3776",
+                     "locator" : "648:10-648:60",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "Equivalent",
+                     "signature" : [ {
+                        "localId" : "3785",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                        "type" : "NamedTypeSpecifier"
+                     }, {
+                        "localId" : "3786",
+                        "name" : "{urn:hl7-org:elm-types:r1}Concept",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "operand" : [ {
+                        "localId" : "3780",
+                        "name" : "ToConcept",
+                        "libraryName" : "FHIRHelpers",
+                        "type" : "FunctionRef",
+                        "signature" : [ {
+                           "localId" : "3781",
+                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : [ {
+                           "localId" : "3778",
+                           "locator" : "648:10-648:15",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "code",
+                           "scope" : "O",
+                           "type" : "Property"
+                        } ]
+                     }, {
+                        "localId" : "3783",
+                        "type" : "ToConcept",
+                        "signature" : [ {
+                           "localId" : "3784",
+                           "name" : "{urn:hl7-org:elm-types:r1}Code",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "operand" : {
+                           "localId" : "3779",
+                           "locator" : "648:19-648:60",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                           "name" : "Flexible Sigmoidoscopy Study Observation",
+                           "type" : "CodeRef"
+                        }
+                     } ]
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "3729",
+            "locator" : "635:1-639:77",
             "name" : "FlexSigDiagnosticReportsWithResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3582",
+                  "r" : "3729",
                   "s" : [ {
                      "value" : [ "","define ","FlexSigDiagnosticReportsWithResults",":\n   " ]
                   }, {
-                     "r" : "3638",
+                     "r" : "3825",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3583",
+                           "r" : "3730",
                            "s" : [ {
-                              "r" : "3598",
+                              "r" : "3751",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "FlexSigDiagnosticReports" ]
@@ -31360,37 +32979,37 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3603",
+                        "r" : "3756",
                         "s" : [ {
                            "value" : [ "where\n      " ]
                         }, {
-                           "r" : "3603",
+                           "r" : "3756",
                            "s" : [ {
-                              "r" : "3604",
+                              "r" : "3757",
                               "s" : [ {
                                  "value" : [ "exists " ]
                               }, {
-                                 "r" : "3610",
+                                 "r" : "3797",
                                  "s" : [ {
-                                    "r" : "3605",
+                                    "r" : "3758",
                                     "s" : [ {
                                        "value" : [ "CRCSMCommon" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3610",
+                                    "r" : "3797",
                                     "s" : [ {
                                        "value" : [ "CollateConclusionCodes","(" ]
                                     }, {
-                                       "r" : "3606",
+                                       "r" : "3759",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ ", " ]
                                     }, {
-                                       "r" : "3607",
+                                       "r" : "3794",
                                        "s" : [ {
                                           "value" : [ "FlexSigObservations" ]
                                        } ]
@@ -31402,31 +33021,31 @@
                            }, {
                               "value" : [ " or\n      " ]
                            }, {
-                              "r" : "3620",
+                              "r" : "3807",
                               "s" : [ {
                                  "value" : [ "exists " ]
                               }, {
-                                 "r" : "3626",
+                                 "r" : "3813",
                                  "s" : [ {
-                                    "r" : "3621",
+                                    "r" : "3808",
                                     "s" : [ {
                                        "value" : [ "CRCSMCommon" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3626",
+                                    "r" : "3813",
                                     "s" : [ {
                                        "value" : [ "ValueQuantityFromObservation","(" ]
                                     }, {
-                                       "r" : "3622",
+                                       "r" : "3809",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "," ]
                                     }, {
-                                       "r" : "3623",
+                                       "r" : "3810",
                                        "s" : [ {
                                           "value" : [ "FollowUpObservations" ]
                                        } ]
@@ -31442,50 +33061,50 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3648",
+               "localId" : "3835",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3649",
+                  "localId" : "3836",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3638",
-               "locator" : "599:4-602:77",
+               "localId" : "3825",
+               "locator" : "636:4-639:77",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3639",
+                  "localId" : "3826",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3640",
+                     "localId" : "3827",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
-                  "localId" : "3583",
-                  "locator" : "599:4-599:29",
+                  "localId" : "3730",
+                  "locator" : "636:4-636:29",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3601",
+                     "localId" : "3754",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3602",
+                        "localId" : "3755",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3598",
-                     "locator" : "599:4-599:27",
+                     "localId" : "3751",
+                     "locator" : "636:4-636:27",
                      "name" : "FlexSigDiagnosticReports",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3599",
+                        "localId" : "3752",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3600",
+                           "localId" : "3753",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -31495,77 +33114,77 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "3603",
-                  "locator" : "600:5-602:77",
+                  "localId" : "3756",
+                  "locator" : "637:5-639:77",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Or",
                   "signature" : [ {
-                     "localId" : "3636",
+                     "localId" : "3823",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "3637",
+                     "localId" : "3824",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "3604",
-                     "locator" : "601:7-601:71",
+                     "localId" : "3757",
+                     "locator" : "638:7-638:71",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Exists",
                      "signature" : [ {
-                        "localId" : "3618",
+                        "localId" : "3805",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3619",
+                           "localId" : "3806",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : {
-                        "localId" : "3610",
-                        "locator" : "601:14-601:71",
+                        "localId" : "3797",
+                        "locator" : "638:14-638:71",
                         "name" : "CollateConclusionCodes",
                         "libraryName" : "CRCSMCommon",
                         "type" : "FunctionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3616",
+                           "localId" : "3803",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3617",
+                              "localId" : "3804",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "signature" : [ {
-                           "localId" : "3611",
+                           "localId" : "3798",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }, {
-                           "localId" : "3612",
+                           "localId" : "3799",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3613",
+                              "localId" : "3800",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "3606",
-                           "locator" : "601:49",
+                           "localId" : "3759",
+                           "locator" : "638:49",
                            "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                            "name" : "D",
                            "type" : "AliasRef"
                         }, {
-                           "localId" : "3607",
-                           "locator" : "601:52-601:70",
+                           "localId" : "3794",
+                           "locator" : "638:52-638:70",
                            "name" : "FlexSigObservations",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3608",
+                              "localId" : "3795",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3609",
+                                 "localId" : "3796",
                                  "name" : "{http://hl7.org/fhir}Observation",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -31573,63 +33192,63 @@
                         } ]
                      }
                   }, {
-                     "localId" : "3620",
-                     "locator" : "602:7-602:77",
+                     "localId" : "3807",
+                     "locator" : "639:7-639:77",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Exists",
                      "signature" : [ {
-                        "localId" : "3634",
+                        "localId" : "3821",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3635",
+                           "localId" : "3822",
                            "name" : "{http://hl7.org/fhir}Quantity",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : {
-                        "localId" : "3626",
-                        "locator" : "602:14-602:77",
+                        "localId" : "3813",
+                        "locator" : "639:14-639:77",
                         "name" : "ValueQuantityFromObservation",
                         "libraryName" : "CRCSMCommon",
                         "type" : "FunctionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3632",
+                           "localId" : "3819",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3633",
+                              "localId" : "3820",
                               "name" : "{http://hl7.org/fhir}Quantity",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "signature" : [ {
-                           "localId" : "3627",
+                           "localId" : "3814",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }, {
-                           "localId" : "3628",
+                           "localId" : "3815",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3629",
+                              "localId" : "3816",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "3622",
-                           "locator" : "602:55",
+                           "localId" : "3809",
+                           "locator" : "639:55",
                            "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                            "name" : "D",
                            "type" : "AliasRef"
                         }, {
-                           "localId" : "3623",
-                           "locator" : "602:57-602:76",
+                           "localId" : "3810",
+                           "locator" : "639:57-639:76",
                            "name" : "FollowUpObservations",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3624",
+                              "localId" : "3811",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3625",
+                                 "localId" : "3812",
                                  "name" : "{http://hl7.org/fhir}Observation",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -31640,8 +33259,8 @@
                }
             }
          }, {
-            "localId" : "3579",
-            "locator" : "595:1-596:44",
+            "localId" : "3726",
+            "locator" : "632:1-633:44",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-FlexSig",
             "context" : "Patient",
@@ -31649,15 +33268,15 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3579",
+                  "r" : "3726",
                   "s" : [ {
                      "value" : [ "// Flex Sig\n","define ","\"de-FlexSig\"",":\n  " ]
                   }, {
-                     "r" : "3580",
+                     "r" : "3727",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "3643",
+                        "r" : "3830",
                         "s" : [ {
                            "value" : [ "FlexSigDiagnosticReportsWithResults" ]
                         } ]
@@ -31666,29 +33285,29 @@
                }
             } ],
             "expression" : {
-               "localId" : "3580",
-               "locator" : "596:3-596:44",
+               "localId" : "3727",
+               "locator" : "633:3-633:44",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "3646",
+                  "localId" : "3833",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3647",
+                     "localId" : "3834",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "3643",
-                  "locator" : "596:10-596:44",
+                  "localId" : "3830",
+                  "locator" : "633:10-633:44",
                   "name" : "FlexSigDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3644",
+                     "localId" : "3831",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3645",
+                        "localId" : "3832",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -31696,34 +33315,34 @@
                }
             }
          }, {
-            "localId" : "3666",
-            "locator" : "668:1-677:44",
+            "localId" : "3853",
+            "locator" : "707:1-716:44",
             "name" : "CRCScreeningHistory",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3666",
+                  "r" : "3853",
                   "s" : [ {
                      "value" : [ "","define ","CRCScreeningHistory",":\n  " ]
                   }, {
-                     "r" : "3708",
+                     "r" : "3895",
                      "s" : [ {
-                        "r" : "3698",
+                        "r" : "3885",
                         "s" : [ {
-                           "r" : "3683",
+                           "r" : "3870",
                            "s" : [ {
-                              "r" : "3673",
+                              "r" : "3860",
                               "s" : [ {
-                                 "r" : "3667",
+                                 "r" : "3854",
                                  "s" : [ {
                                     "value" : [ "FOBTDiagnosticReportsWithResults" ]
                                  } ]
                               }, {
                                  "value" : [ "\n  union\n  " ]
                               }, {
-                                 "r" : "3670",
+                                 "r" : "3857",
                                  "s" : [ {
                                     "value" : [ "StoolDNAFITDiagnosticReportsWithResults" ]
                                  } ]
@@ -31731,7 +33350,7 @@
                            }, {
                               "value" : [ "\n  union\n  " ]
                            }, {
-                              "r" : "3680",
+                              "r" : "3867",
                               "s" : [ {
                                  "value" : [ "ColonoscopyDiagnosticReportsWithResults" ]
                               } ]
@@ -31739,7 +33358,7 @@
                         }, {
                            "value" : [ "\n  union\n  " ]
                         }, {
-                           "r" : "3690",
+                           "r" : "3877",
                            "s" : [ {
                               "value" : [ "FlexSigDiagnosticReportsWithResults" ]
                            } ]
@@ -31747,7 +33366,7 @@
                      }, {
                         "value" : [ "\n  union\n  " ]
                      }, {
-                        "r" : "3705",
+                        "r" : "3892",
                         "s" : [ {
                            "value" : [ "CTColonographyDiagnosticReportsWithResults" ]
                         } ]
@@ -31756,177 +33375,177 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3983",
+               "localId" : "4170",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "3984",
+                  "localId" : "4171",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3708",
-               "locator" : "669:3-677:44",
+               "localId" : "3895",
+               "locator" : "708:3-716:44",
                "type" : "Union",
                "resultTypeSpecifier" : {
-                  "localId" : "3713",
+                  "localId" : "3900",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3714",
+                     "localId" : "3901",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "signature" : [ {
-                  "localId" : "3709",
+                  "localId" : "3896",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3710",
+                     "localId" : "3897",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "3711",
+                  "localId" : "3898",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3712",
+                     "localId" : "3899",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : [ {
-                  "localId" : "3698",
-                  "locator" : "669:3-675:37",
+                  "localId" : "3885",
+                  "locator" : "708:3-714:37",
                   "type" : "Union",
                   "resultTypeSpecifier" : {
-                     "localId" : "3703",
+                     "localId" : "3890",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3704",
+                        "localId" : "3891",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "signature" : [ {
-                     "localId" : "3699",
+                     "localId" : "3886",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3700",
+                        "localId" : "3887",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "3701",
+                     "localId" : "3888",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3702",
+                        "localId" : "3889",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : [ {
-                     "localId" : "3673",
-                     "locator" : "669:3-671:41",
+                     "localId" : "3860",
+                     "locator" : "708:3-710:41",
                      "type" : "Union",
                      "resultTypeSpecifier" : {
-                        "localId" : "3678",
+                        "localId" : "3865",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3679",
+                           "localId" : "3866",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3674",
+                        "localId" : "3861",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3675",
+                           "localId" : "3862",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3676",
+                        "localId" : "3863",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3677",
+                           "localId" : "3864",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3667",
-                        "locator" : "669:3-669:34",
+                        "localId" : "3854",
+                        "locator" : "708:3-708:34",
                         "name" : "FOBTDiagnosticReportsWithResults",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3668",
+                           "localId" : "3855",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3669",
+                              "localId" : "3856",
                               "name" : "{http://hl7.org/fhir}DiagnosticReport",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "3670",
-                        "locator" : "671:3-671:41",
+                        "localId" : "3857",
+                        "locator" : "710:3-710:41",
                         "name" : "StoolDNAFITDiagnosticReportsWithResults",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3671",
+                           "localId" : "3858",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3672",
+                              "localId" : "3859",
                               "name" : "{http://hl7.org/fhir}DiagnosticReport",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      } ]
                   }, {
-                     "localId" : "3693",
+                     "localId" : "3880",
                      "type" : "Union",
                      "signature" : [ {
-                        "localId" : "3694",
+                        "localId" : "3881",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3695",
+                           "localId" : "3882",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3696",
+                        "localId" : "3883",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3697",
+                           "localId" : "3884",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "3680",
-                        "locator" : "673:3-673:41",
+                        "localId" : "3867",
+                        "locator" : "712:3-712:41",
                         "name" : "ColonoscopyDiagnosticReportsWithResults",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3681",
+                           "localId" : "3868",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3682",
+                              "localId" : "3869",
                               "name" : "{http://hl7.org/fhir}DiagnosticReport",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "3690",
-                        "locator" : "675:3-675:37",
+                        "localId" : "3877",
+                        "locator" : "714:3-714:37",
                         "name" : "FlexSigDiagnosticReportsWithResults",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3691",
+                           "localId" : "3878",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3692",
+                              "localId" : "3879",
                               "name" : "{http://hl7.org/fhir}DiagnosticReport",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -31934,15 +33553,15 @@
                      } ]
                   } ]
                }, {
-                  "localId" : "3705",
-                  "locator" : "677:3-677:44",
+                  "localId" : "3892",
+                  "locator" : "716:3-716:44",
                   "name" : "CTColonographyDiagnosticReportsWithResults",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3706",
+                     "localId" : "3893",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3707",
+                        "localId" : "3894",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -31950,8 +33569,8 @@
                } ]
             }
          }, {
-            "localId" : "3663",
-            "locator" : "665:1-666:56",
+            "localId" : "3850",
+            "locator" : "704:1-705:56",
             "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
             "name" : "MostRecentColorectalScreeningDiagnosticReport",
             "context" : "Patient",
@@ -31959,24 +33578,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3663",
+                  "r" : "3850",
                   "s" : [ {
                      "value" : [ "","define ","MostRecentColorectalScreeningDiagnosticReport",":\n  " ]
                   }, {
-                     "r" : "3720",
+                     "r" : "3907",
                      "s" : [ {
-                        "r" : "3664",
+                        "r" : "3851",
                         "s" : [ {
                            "value" : [ "Common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "3720",
+                        "r" : "3907",
                         "s" : [ {
                            "value" : [ "MostRecentDiagnosticReport","(" ]
                         }, {
-                           "r" : "3717",
+                           "r" : "3904",
                            "s" : [ {
                               "value" : [ "CRCScreeningHistory" ]
                            } ]
@@ -31988,31 +33607,31 @@
                }
             } ],
             "expression" : {
-               "localId" : "3720",
-               "locator" : "666:3-666:56",
+               "localId" : "3907",
+               "locator" : "705:3-705:56",
                "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                "name" : "MostRecentDiagnosticReport",
                "libraryName" : "Common",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "3721",
+                  "localId" : "3908",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3722",
+                     "localId" : "3909",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : [ {
-                  "localId" : "3717",
-                  "locator" : "666:37-666:55",
+                  "localId" : "3904",
+                  "locator" : "705:37-705:55",
                   "name" : "CRCScreeningHistory",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3718",
+                     "localId" : "3905",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3719",
+                        "localId" : "3906",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -32020,24 +33639,24 @@
                } ]
             }
          }, {
-            "localId" : "3660",
-            "locator" : "635:1-660:9",
+            "localId" : "3847",
+            "locator" : "674:1-699:9",
             "name" : "MostRecentColorectalScreeningTestResults",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3660",
+                  "r" : "3847",
                   "s" : [ {
                      "value" : [ "","define ","MostRecentColorectalScreeningTestResults",":\n  " ]
                   }, {
-                     "r" : "3891",
+                     "r" : "4078",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3661",
+                           "r" : "3848",
                            "s" : [ {
-                              "r" : "3723",
+                              "r" : "3910",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "MostRecentColorectalScreeningDiagnosticReport" ]
@@ -32050,30 +33669,30 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3724",
+                        "r" : "3911",
                         "s" : [ {
                            "value" : [ "return\n      " ]
                         }, {
-                           "r" : "3725",
+                           "r" : "3912",
                            "s" : [ {
                               "value" : [ "case\n        " ]
                            }, {
-                              "r" : "3726",
+                              "r" : "3913",
                               "s" : [ {
                                  "value" : [ "when " ]
                               }, {
-                                 "r" : "3730",
+                                 "r" : "3917",
                                  "s" : [ {
-                                    "r" : "3728",
+                                    "r" : "3915",
                                     "s" : [ {
-                                       "r" : "3727",
+                                       "r" : "3914",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3728",
+                                       "r" : "3915",
                                        "s" : [ {
                                           "value" : [ "code" ]
                                        } ]
@@ -32081,7 +33700,7 @@
                                  }, {
                                     "value" : [ " in " ]
                                  }, {
-                                    "r" : "3729",
+                                    "r" : "3916",
                                     "s" : [ {
                                        "value" : [ "\"Colonoscopy Study\"" ]
                                     } ]
@@ -32089,14 +33708,14 @@
                               }, {
                                  "value" : [ " then\n          " ]
                               }, {
-                                 "r" : "3734",
+                                 "r" : "3921",
                                  "s" : [ {
                                     "value" : [ "{ " ]
                                  }, {
                                     "s" : [ {
                                        "value" : [ "modality",": " ]
                                     }, {
-                                       "r" : "3735",
+                                       "r" : "3922",
                                        "s" : [ {
                                           "value" : [ "\"Colonoscopy\"" ]
                                        } ]
@@ -32107,27 +33726,27 @@
                                     "s" : [ {
                                        "value" : [ "results",": " ]
                                     }, {
-                                       "r" : "3741",
+                                       "r" : "3928",
                                        "s" : [ {
-                                          "r" : "3736",
+                                          "r" : "3923",
                                           "s" : [ {
                                              "value" : [ "CRCSMCommon" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3741",
+                                          "r" : "3928",
                                           "s" : [ {
                                              "value" : [ "CollateConclusionCodes","(" ]
                                           }, {
-                                             "r" : "3737",
+                                             "r" : "3924",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ ", " ]
                                           }, {
-                                             "r" : "3738",
+                                             "r" : "3925",
                                              "s" : [ {
                                                 "value" : [ "ColonoscopyObservations" ]
                                              } ]
@@ -32143,22 +33762,22 @@
                            }, {
                               "value" : [ "\n        " ]
                            }, {
-                              "r" : "3755",
+                              "r" : "3942",
                               "s" : [ {
                                  "value" : [ "when " ]
                               }, {
-                                 "r" : "3759",
+                                 "r" : "3946",
                                  "s" : [ {
-                                    "r" : "3757",
+                                    "r" : "3944",
                                     "s" : [ {
-                                       "r" : "3756",
+                                       "r" : "3943",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3757",
+                                       "r" : "3944",
                                        "s" : [ {
                                           "value" : [ "code" ]
                                        } ]
@@ -32166,7 +33785,7 @@
                                  }, {
                                     "value" : [ " in " ]
                                  }, {
-                                    "r" : "3758",
+                                    "r" : "3945",
                                     "s" : [ {
                                        "value" : [ "\"CT Colonography Study\"" ]
                                     } ]
@@ -32174,14 +33793,14 @@
                               }, {
                                  "value" : [ " then\n          " ]
                               }, {
-                                 "r" : "3763",
+                                 "r" : "3950",
                                  "s" : [ {
                                     "value" : [ "{ " ]
                                  }, {
                                     "s" : [ {
                                        "value" : [ "modality",": " ]
                                     }, {
-                                       "r" : "3764",
+                                       "r" : "3951",
                                        "s" : [ {
                                           "value" : [ "\"CT Colonography\"" ]
                                        } ]
@@ -32192,27 +33811,27 @@
                                     "s" : [ {
                                        "value" : [ "results",": " ]
                                     }, {
-                                       "r" : "3770",
+                                       "r" : "3957",
                                        "s" : [ {
-                                          "r" : "3765",
+                                          "r" : "3952",
                                           "s" : [ {
                                              "value" : [ "CRCSMCommon" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3770",
+                                          "r" : "3957",
                                           "s" : [ {
                                              "value" : [ "CollateConclusionCodes","(" ]
                                           }, {
-                                             "r" : "3766",
+                                             "r" : "3953",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ ", " ]
                                           }, {
-                                             "r" : "3767",
+                                             "r" : "3954",
                                              "s" : [ {
                                                 "value" : [ "CTColonographyObservations" ]
                                              } ]
@@ -32228,22 +33847,22 @@
                            }, {
                               "value" : [ "\n        " ]
                            }, {
-                              "r" : "3784",
+                              "r" : "3971",
                               "s" : [ {
                                  "value" : [ "when " ]
                               }, {
-                                 "r" : "3788",
+                                 "r" : "3975",
                                  "s" : [ {
-                                    "r" : "3786",
+                                    "r" : "3973",
                                     "s" : [ {
-                                       "r" : "3785",
+                                       "r" : "3972",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3786",
+                                       "r" : "3973",
                                        "s" : [ {
                                           "value" : [ "code" ]
                                        } ]
@@ -32251,7 +33870,7 @@
                                  }, {
                                     "value" : [ " in " ]
                                  }, {
-                                    "r" : "3787",
+                                    "r" : "3974",
                                     "s" : [ {
                                        "value" : [ "\"Fecal Occult Blood Test\"" ]
                                     } ]
@@ -32259,14 +33878,14 @@
                               }, {
                                  "value" : [ " then\n          " ]
                               }, {
-                                 "r" : "3792",
+                                 "r" : "3979",
                                  "s" : [ {
                                     "value" : [ "{ " ]
                                  }, {
                                     "s" : [ {
                                        "value" : [ "modality",": " ]
                                     }, {
-                                       "r" : "3793",
+                                       "r" : "3980",
                                        "s" : [ {
                                           "value" : [ "\"FOBT\"" ]
                                        } ]
@@ -32277,27 +33896,27 @@
                                     "s" : [ {
                                        "value" : [ "results",": " ]
                                     }, {
-                                       "r" : "3799",
+                                       "r" : "3986",
                                        "s" : [ {
-                                          "r" : "3794",
+                                          "r" : "3981",
                                           "s" : [ {
                                              "value" : [ "CRCSMCommon" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3799",
+                                          "r" : "3986",
                                           "s" : [ {
                                              "value" : [ "CollateConclusionCodes","(" ]
                                           }, {
-                                             "r" : "3795",
+                                             "r" : "3982",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ ", " ]
                                           }, {
-                                             "r" : "3796",
+                                             "r" : "3983",
                                              "s" : [ {
                                                 "value" : [ "FOBTObservations" ]
                                              } ]
@@ -32313,22 +33932,22 @@
                            }, {
                               "value" : [ "\n        " ]
                            }, {
-                              "r" : "3813",
+                              "r" : "4000",
                               "s" : [ {
                                  "value" : [ "when " ]
                               }, {
-                                 "r" : "3817",
+                                 "r" : "4004",
                                  "s" : [ {
-                                    "r" : "3815",
+                                    "r" : "4002",
                                     "s" : [ {
-                                       "r" : "3814",
+                                       "r" : "4001",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3815",
+                                       "r" : "4002",
                                        "s" : [ {
                                           "value" : [ "code" ]
                                        } ]
@@ -32336,7 +33955,7 @@
                                  }, {
                                     "value" : [ " in " ]
                                  }, {
-                                    "r" : "3816",
+                                    "r" : "4003",
                                     "s" : [ {
                                        "value" : [ "\"Stool DNA-FIT\"" ]
                                     } ]
@@ -32344,14 +33963,14 @@
                               }, {
                                  "value" : [ " then\n          " ]
                               }, {
-                                 "r" : "3821",
+                                 "r" : "4008",
                                  "s" : [ {
                                     "value" : [ "{ " ]
                                  }, {
                                     "s" : [ {
                                        "value" : [ "modality",": " ]
                                     }, {
-                                       "r" : "3822",
+                                       "r" : "4009",
                                        "s" : [ {
                                           "value" : [ "\"sDNA-FIT\"" ]
                                        } ]
@@ -32362,27 +33981,27 @@
                                     "s" : [ {
                                        "value" : [ "results",": " ]
                                     }, {
-                                       "r" : "3828",
+                                       "r" : "4015",
                                        "s" : [ {
-                                          "r" : "3823",
+                                          "r" : "4010",
                                           "s" : [ {
                                              "value" : [ "CRCSMCommon" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3828",
+                                          "r" : "4015",
                                           "s" : [ {
                                              "value" : [ "CollateConclusionCodes","(" ]
                                           }, {
-                                             "r" : "3824",
+                                             "r" : "4011",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ ", " ]
                                           }, {
-                                             "r" : "3825",
+                                             "r" : "4012",
                                              "s" : [ {
                                                 "value" : [ "StoolDNAFITObservations" ]
                                              } ]
@@ -32398,22 +34017,22 @@
                            }, {
                               "value" : [ "\n        " ]
                            }, {
-                              "r" : "3842",
+                              "r" : "4029",
                               "s" : [ {
                                  "value" : [ "when " ]
                               }, {
-                                 "r" : "3846",
+                                 "r" : "4033",
                                  "s" : [ {
-                                    "r" : "3844",
+                                    "r" : "4031",
                                     "s" : [ {
-                                       "r" : "3843",
+                                       "r" : "4030",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3844",
+                                       "r" : "4031",
                                        "s" : [ {
                                           "value" : [ "code" ]
                                        } ]
@@ -32421,7 +34040,7 @@
                                  }, {
                                     "value" : [ " in " ]
                                  }, {
-                                    "r" : "3845",
+                                    "r" : "4032",
                                     "s" : [ {
                                        "value" : [ "\"Flexible Sigmoidoscopy Study\"" ]
                                     } ]
@@ -32429,14 +34048,14 @@
                               }, {
                                  "value" : [ " then\n          " ]
                               }, {
-                                 "r" : "3850",
+                                 "r" : "4037",
                                  "s" : [ {
                                     "value" : [ "{ " ]
                                  }, {
                                     "s" : [ {
                                        "value" : [ "modality",": " ]
                                     }, {
-                                       "r" : "3851",
+                                       "r" : "4038",
                                        "s" : [ {
                                           "value" : [ "\"Flexible Sigmoidoscopy\"" ]
                                        } ]
@@ -32447,27 +34066,27 @@
                                     "s" : [ {
                                        "value" : [ "results",": " ]
                                     }, {
-                                       "r" : "3857",
+                                       "r" : "4044",
                                        "s" : [ {
-                                          "r" : "3852",
+                                          "r" : "4039",
                                           "s" : [ {
                                              "value" : [ "CRCSMCommon" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3857",
+                                          "r" : "4044",
                                           "s" : [ {
                                              "value" : [ "CollateConclusionCodes","(" ]
                                           }, {
-                                             "r" : "3853",
+                                             "r" : "4040",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ ", " ]
                                           }, {
-                                             "r" : "3854",
+                                             "r" : "4041",
                                              "s" : [ {
                                                 "value" : [ "FlexSigObservations" ]
                                              } ]
@@ -32481,7 +34100,7 @@
                                  } ]
                               } ]
                            }, {
-                              "r" : "3871",
+                              "r" : "4058",
                               "value" : [ "\n        else ","null","\n      end" ]
                            } ]
                         } ]
@@ -32490,24 +34109,24 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "3971",
+               "localId" : "4158",
                "type" : "TupleTypeSpecifier",
                "element" : [ {
-                  "localId" : "3972",
+                  "localId" : "4159",
                   "name" : "modality",
                   "elementType" : {
-                     "localId" : "3973",
+                     "localId" : "4160",
                      "name" : "{urn:hl7-org:elm-types:r1}Code",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "3974",
+                  "localId" : "4161",
                   "name" : "results",
                   "elementType" : {
-                     "localId" : "3975",
+                     "localId" : "4162",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3976",
+                        "localId" : "4163",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -32515,28 +34134,28 @@
                } ]
             },
             "expression" : {
-               "localId" : "3891",
-               "locator" : "636:3-660:9",
+               "localId" : "4078",
+               "locator" : "675:3-699:9",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3892",
+                  "localId" : "4079",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "3893",
+                     "localId" : "4080",
                      "name" : "modality",
                      "elementType" : {
-                        "localId" : "3894",
+                        "localId" : "4081",
                         "name" : "{urn:hl7-org:elm-types:r1}Code",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "3895",
+                     "localId" : "4082",
                      "name" : "results",
                      "elementType" : {
-                        "localId" : "3896",
+                        "localId" : "4083",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3897",
+                           "localId" : "4084",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -32544,13 +34163,13 @@
                   } ]
                },
                "source" : [ {
-                  "localId" : "3661",
-                  "locator" : "636:3-636:49",
+                  "localId" : "3848",
+                  "locator" : "675:3-675:49",
                   "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                   "alias" : "D",
                   "expression" : {
-                     "localId" : "3723",
-                     "locator" : "636:3-636:47",
+                     "localId" : "3910",
+                     "locator" : "675:3-675:47",
                      "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                      "name" : "MostRecentColorectalScreeningDiagnosticReport",
                      "type" : "ExpressionRef"
@@ -32559,27 +34178,27 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "3724",
-                  "locator" : "637:5-660:9",
+                  "localId" : "3911",
+                  "locator" : "676:5-699:9",
                   "resultTypeSpecifier" : {
-                     "localId" : "3885",
+                     "localId" : "4072",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3886",
+                        "localId" : "4073",
                         "name" : "modality",
                         "elementType" : {
-                           "localId" : "3887",
+                           "localId" : "4074",
                            "name" : "{urn:hl7-org:elm-types:r1}Code",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3888",
+                        "localId" : "4075",
                         "name" : "results",
                         "elementType" : {
-                           "localId" : "3889",
+                           "localId" : "4076",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3890",
+                              "localId" : "4077",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -32587,28 +34206,28 @@
                      } ]
                   },
                   "expression" : {
-                     "localId" : "3725",
-                     "locator" : "638:7-660:9",
+                     "localId" : "3912",
+                     "locator" : "677:7-699:9",
                      "type" : "Case",
                      "resultTypeSpecifier" : {
-                        "localId" : "3879",
+                        "localId" : "4066",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3880",
+                           "localId" : "4067",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3881",
+                              "localId" : "4068",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3882",
+                           "localId" : "4069",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3883",
+                              "localId" : "4070",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3884",
+                                 "localId" : "4071",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -32616,31 +34235,31 @@
                         } ]
                      },
                      "caseItem" : [ {
-                        "localId" : "3726",
-                        "locator" : "639:9-642:11",
+                        "localId" : "3913",
+                        "locator" : "678:9-681:11",
                         "when" : {
-                           "localId" : "3730",
-                           "locator" : "639:14-639:42",
+                           "localId" : "3917",
+                           "locator" : "678:14-678:42",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "InValueSet",
                            "signature" : [ {
-                              "localId" : "3733",
+                              "localId" : "3920",
                               "name" : "{urn:hl7-org:elm-types:r1}Concept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "code" : {
-                              "localId" : "3731",
+                              "localId" : "3918",
                               "name" : "ToConcept",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3732",
+                                 "localId" : "3919",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3728",
-                                 "locator" : "639:14-639:19",
+                                 "localId" : "3915",
+                                 "locator" : "678:14-678:19",
                                  "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                                  "path" : "code",
                                  "scope" : "D",
@@ -32648,36 +34267,36 @@
                               } ]
                            },
                            "valueset" : {
-                              "localId" : "3729",
-                              "locator" : "639:24-639:42",
+                              "localId" : "3916",
+                              "locator" : "678:24-678:42",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                               "name" : "Colonoscopy Study",
                               "preserve" : true
                            }
                         },
                         "then" : {
-                           "localId" : "3734",
-                           "locator" : "640:11-642:11",
+                           "localId" : "3921",
+                           "locator" : "679:11-681:11",
                            "type" : "Tuple",
                            "resultTypeSpecifier" : {
-                              "localId" : "3749",
+                              "localId" : "3936",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3750",
+                                 "localId" : "3937",
                                  "name" : "modality",
                                  "elementType" : {
-                                    "localId" : "3751",
+                                    "localId" : "3938",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3752",
+                                 "localId" : "3939",
                                  "name" : "results",
                                  "elementType" : {
-                                    "localId" : "3753",
+                                    "localId" : "3940",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3754",
+                                       "localId" : "3941",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -32687,8 +34306,8 @@
                            "element" : [ {
                               "name" : "modality",
                               "value" : {
-                                 "localId" : "3735",
-                                 "locator" : "640:23-640:35",
+                                 "localId" : "3922",
+                                 "locator" : "679:23-679:35",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "Colonoscopy",
                                  "type" : "CodeRef"
@@ -32696,49 +34315,49 @@
                            }, {
                               "name" : "results",
                               "value" : {
-                                 "localId" : "3741",
-                                 "locator" : "641:22-641:83",
+                                 "localId" : "3928",
+                                 "locator" : "680:22-680:83",
                                  "name" : "CollateConclusionCodes",
                                  "libraryName" : "CRCSMCommon",
                                  "type" : "FunctionRef",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3747",
+                                    "localId" : "3934",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3748",
+                                       "localId" : "3935",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "signature" : [ {
-                                    "localId" : "3742",
+                                    "localId" : "3929",
                                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3743",
+                                    "localId" : "3930",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3744",
+                                       "localId" : "3931",
                                        "name" : "{http://hl7.org/fhir}Observation",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3737",
-                                    "locator" : "641:57",
+                                    "localId" : "3924",
+                                    "locator" : "680:57",
                                     "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "name" : "D",
                                     "type" : "AliasRef"
                                  }, {
-                                    "localId" : "3738",
-                                    "locator" : "641:60-641:82",
+                                    "localId" : "3925",
+                                    "locator" : "680:60-680:82",
                                     "name" : "ColonoscopyObservations",
                                     "type" : "ExpressionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3739",
+                                       "localId" : "3926",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3740",
+                                          "localId" : "3927",
                                           "name" : "{http://hl7.org/fhir}Observation",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -32748,31 +34367,31 @@
                            } ]
                         }
                      }, {
-                        "localId" : "3755",
-                        "locator" : "643:9-646:11",
+                        "localId" : "3942",
+                        "locator" : "682:9-685:11",
                         "when" : {
-                           "localId" : "3759",
-                           "locator" : "643:14-643:46",
+                           "localId" : "3946",
+                           "locator" : "682:14-682:46",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "InValueSet",
                            "signature" : [ {
-                              "localId" : "3762",
+                              "localId" : "3949",
                               "name" : "{urn:hl7-org:elm-types:r1}Concept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "code" : {
-                              "localId" : "3760",
+                              "localId" : "3947",
                               "name" : "ToConcept",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3761",
+                                 "localId" : "3948",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3757",
-                                 "locator" : "643:14-643:19",
+                                 "localId" : "3944",
+                                 "locator" : "682:14-682:19",
                                  "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                                  "path" : "code",
                                  "scope" : "D",
@@ -32780,36 +34399,36 @@
                               } ]
                            },
                            "valueset" : {
-                              "localId" : "3758",
-                              "locator" : "643:24-643:46",
+                              "localId" : "3945",
+                              "locator" : "682:24-682:46",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                               "name" : "CT Colonography Study",
                               "preserve" : true
                            }
                         },
                         "then" : {
-                           "localId" : "3763",
-                           "locator" : "644:11-646:11",
+                           "localId" : "3950",
+                           "locator" : "683:11-685:11",
                            "type" : "Tuple",
                            "resultTypeSpecifier" : {
-                              "localId" : "3778",
+                              "localId" : "3965",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3779",
+                                 "localId" : "3966",
                                  "name" : "modality",
                                  "elementType" : {
-                                    "localId" : "3780",
+                                    "localId" : "3967",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3781",
+                                 "localId" : "3968",
                                  "name" : "results",
                                  "elementType" : {
-                                    "localId" : "3782",
+                                    "localId" : "3969",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3783",
+                                       "localId" : "3970",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -32819,8 +34438,8 @@
                            "element" : [ {
                               "name" : "modality",
                               "value" : {
-                                 "localId" : "3764",
-                                 "locator" : "644:23-644:39",
+                                 "localId" : "3951",
+                                 "locator" : "683:23-683:39",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "CT Colonography",
                                  "type" : "CodeRef"
@@ -32828,49 +34447,49 @@
                            }, {
                               "name" : "results",
                               "value" : {
-                                 "localId" : "3770",
-                                 "locator" : "645:22-645:86",
+                                 "localId" : "3957",
+                                 "locator" : "684:22-684:86",
                                  "name" : "CollateConclusionCodes",
                                  "libraryName" : "CRCSMCommon",
                                  "type" : "FunctionRef",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3776",
+                                    "localId" : "3963",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3777",
+                                       "localId" : "3964",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "signature" : [ {
-                                    "localId" : "3771",
+                                    "localId" : "3958",
                                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3772",
+                                    "localId" : "3959",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3773",
+                                       "localId" : "3960",
                                        "name" : "{http://hl7.org/fhir}Observation",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3766",
-                                    "locator" : "645:57",
+                                    "localId" : "3953",
+                                    "locator" : "684:57",
                                     "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "name" : "D",
                                     "type" : "AliasRef"
                                  }, {
-                                    "localId" : "3767",
-                                    "locator" : "645:60-645:85",
+                                    "localId" : "3954",
+                                    "locator" : "684:60-684:85",
                                     "name" : "CTColonographyObservations",
                                     "type" : "ExpressionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3768",
+                                       "localId" : "3955",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3769",
+                                          "localId" : "3956",
                                           "name" : "{http://hl7.org/fhir}Observation",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -32880,31 +34499,31 @@
                            } ]
                         }
                      }, {
-                        "localId" : "3784",
-                        "locator" : "647:9-650:11",
+                        "localId" : "3971",
+                        "locator" : "686:9-689:11",
                         "when" : {
-                           "localId" : "3788",
-                           "locator" : "647:14-647:48",
+                           "localId" : "3975",
+                           "locator" : "686:14-686:48",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "InValueSet",
                            "signature" : [ {
-                              "localId" : "3791",
+                              "localId" : "3978",
                               "name" : "{urn:hl7-org:elm-types:r1}Concept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "code" : {
-                              "localId" : "3789",
+                              "localId" : "3976",
                               "name" : "ToConcept",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3790",
+                                 "localId" : "3977",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3786",
-                                 "locator" : "647:14-647:19",
+                                 "localId" : "3973",
+                                 "locator" : "686:14-686:19",
                                  "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                                  "path" : "code",
                                  "scope" : "D",
@@ -32912,36 +34531,36 @@
                               } ]
                            },
                            "valueset" : {
-                              "localId" : "3787",
-                              "locator" : "647:24-647:48",
+                              "localId" : "3974",
+                              "locator" : "686:24-686:48",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                               "name" : "Fecal Occult Blood Test",
                               "preserve" : true
                            }
                         },
                         "then" : {
-                           "localId" : "3792",
-                           "locator" : "648:11-650:11",
+                           "localId" : "3979",
+                           "locator" : "687:11-689:11",
                            "type" : "Tuple",
                            "resultTypeSpecifier" : {
-                              "localId" : "3807",
+                              "localId" : "3994",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3808",
+                                 "localId" : "3995",
                                  "name" : "modality",
                                  "elementType" : {
-                                    "localId" : "3809",
+                                    "localId" : "3996",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3810",
+                                 "localId" : "3997",
                                  "name" : "results",
                                  "elementType" : {
-                                    "localId" : "3811",
+                                    "localId" : "3998",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3812",
+                                       "localId" : "3999",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -32951,8 +34570,8 @@
                            "element" : [ {
                               "name" : "modality",
                               "value" : {
-                                 "localId" : "3793",
-                                 "locator" : "648:23-648:28",
+                                 "localId" : "3980",
+                                 "locator" : "687:23-687:28",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "FOBT",
                                  "type" : "CodeRef"
@@ -32960,49 +34579,49 @@
                            }, {
                               "name" : "results",
                               "value" : {
-                                 "localId" : "3799",
-                                 "locator" : "649:22-649:76",
+                                 "localId" : "3986",
+                                 "locator" : "688:22-688:76",
                                  "name" : "CollateConclusionCodes",
                                  "libraryName" : "CRCSMCommon",
                                  "type" : "FunctionRef",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3805",
+                                    "localId" : "3992",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3806",
+                                       "localId" : "3993",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "signature" : [ {
-                                    "localId" : "3800",
+                                    "localId" : "3987",
                                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3801",
+                                    "localId" : "3988",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3802",
+                                       "localId" : "3989",
                                        "name" : "{http://hl7.org/fhir}Observation",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3795",
-                                    "locator" : "649:57",
+                                    "localId" : "3982",
+                                    "locator" : "688:57",
                                     "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "name" : "D",
                                     "type" : "AliasRef"
                                  }, {
-                                    "localId" : "3796",
-                                    "locator" : "649:60-649:75",
+                                    "localId" : "3983",
+                                    "locator" : "688:60-688:75",
                                     "name" : "FOBTObservations",
                                     "type" : "ExpressionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3797",
+                                       "localId" : "3984",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3798",
+                                          "localId" : "3985",
                                           "name" : "{http://hl7.org/fhir}Observation",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -33012,31 +34631,31 @@
                            } ]
                         }
                      }, {
-                        "localId" : "3813",
-                        "locator" : "651:9-654:11",
+                        "localId" : "4000",
+                        "locator" : "690:9-693:11",
                         "when" : {
-                           "localId" : "3817",
-                           "locator" : "651:14-651:38",
+                           "localId" : "4004",
+                           "locator" : "690:14-690:38",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "InValueSet",
                            "signature" : [ {
-                              "localId" : "3820",
+                              "localId" : "4007",
                               "name" : "{urn:hl7-org:elm-types:r1}Concept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "code" : {
-                              "localId" : "3818",
+                              "localId" : "4005",
                               "name" : "ToConcept",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3819",
+                                 "localId" : "4006",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3815",
-                                 "locator" : "651:14-651:19",
+                                 "localId" : "4002",
+                                 "locator" : "690:14-690:19",
                                  "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                                  "path" : "code",
                                  "scope" : "D",
@@ -33044,36 +34663,36 @@
                               } ]
                            },
                            "valueset" : {
-                              "localId" : "3816",
-                              "locator" : "651:24-651:38",
+                              "localId" : "4003",
+                              "locator" : "690:24-690:38",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                               "name" : "Stool DNA-FIT",
                               "preserve" : true
                            }
                         },
                         "then" : {
-                           "localId" : "3821",
-                           "locator" : "652:11-654:11",
+                           "localId" : "4008",
+                           "locator" : "691:11-693:11",
                            "type" : "Tuple",
                            "resultTypeSpecifier" : {
-                              "localId" : "3836",
+                              "localId" : "4023",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3837",
+                                 "localId" : "4024",
                                  "name" : "modality",
                                  "elementType" : {
-                                    "localId" : "3838",
+                                    "localId" : "4025",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3839",
+                                 "localId" : "4026",
                                  "name" : "results",
                                  "elementType" : {
-                                    "localId" : "3840",
+                                    "localId" : "4027",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3841",
+                                       "localId" : "4028",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -33083,8 +34702,8 @@
                            "element" : [ {
                               "name" : "modality",
                               "value" : {
-                                 "localId" : "3822",
-                                 "locator" : "652:23-652:32",
+                                 "localId" : "4009",
+                                 "locator" : "691:23-691:32",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "sDNA-FIT",
                                  "type" : "CodeRef"
@@ -33092,49 +34711,49 @@
                            }, {
                               "name" : "results",
                               "value" : {
-                                 "localId" : "3828",
-                                 "locator" : "653:22-653:83",
+                                 "localId" : "4015",
+                                 "locator" : "692:22-692:83",
                                  "name" : "CollateConclusionCodes",
                                  "libraryName" : "CRCSMCommon",
                                  "type" : "FunctionRef",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3834",
+                                    "localId" : "4021",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3835",
+                                       "localId" : "4022",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "signature" : [ {
-                                    "localId" : "3829",
+                                    "localId" : "4016",
                                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3830",
+                                    "localId" : "4017",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3831",
+                                       "localId" : "4018",
                                        "name" : "{http://hl7.org/fhir}Observation",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3824",
-                                    "locator" : "653:57",
+                                    "localId" : "4011",
+                                    "locator" : "692:57",
                                     "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "name" : "D",
                                     "type" : "AliasRef"
                                  }, {
-                                    "localId" : "3825",
-                                    "locator" : "653:60-653:82",
+                                    "localId" : "4012",
+                                    "locator" : "692:60-692:82",
                                     "name" : "StoolDNAFITObservations",
                                     "type" : "ExpressionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3826",
+                                       "localId" : "4013",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3827",
+                                          "localId" : "4014",
                                           "name" : "{http://hl7.org/fhir}Observation",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -33144,31 +34763,31 @@
                            } ]
                         }
                      }, {
-                        "localId" : "3842",
-                        "locator" : "655:9-658:11",
+                        "localId" : "4029",
+                        "locator" : "694:9-697:11",
                         "when" : {
-                           "localId" : "3846",
-                           "locator" : "655:14-655:53",
+                           "localId" : "4033",
+                           "locator" : "694:14-694:53",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "InValueSet",
                            "signature" : [ {
-                              "localId" : "3849",
+                              "localId" : "4036",
                               "name" : "{urn:hl7-org:elm-types:r1}Concept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "code" : {
-                              "localId" : "3847",
+                              "localId" : "4034",
                               "name" : "ToConcept",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3848",
+                                 "localId" : "4035",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3844",
-                                 "locator" : "655:14-655:19",
+                                 "localId" : "4031",
+                                 "locator" : "694:14-694:19",
                                  "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                                  "path" : "code",
                                  "scope" : "D",
@@ -33176,36 +34795,36 @@
                               } ]
                            },
                            "valueset" : {
-                              "localId" : "3845",
-                              "locator" : "655:24-655:53",
+                              "localId" : "4032",
+                              "locator" : "694:24-694:53",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                               "name" : "Flexible Sigmoidoscopy Study",
                               "preserve" : true
                            }
                         },
                         "then" : {
-                           "localId" : "3850",
-                           "locator" : "656:11-658:11",
+                           "localId" : "4037",
+                           "locator" : "695:11-697:11",
                            "type" : "Tuple",
                            "resultTypeSpecifier" : {
-                              "localId" : "3865",
+                              "localId" : "4052",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3866",
+                                 "localId" : "4053",
                                  "name" : "modality",
                                  "elementType" : {
-                                    "localId" : "3867",
+                                    "localId" : "4054",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3868",
+                                 "localId" : "4055",
                                  "name" : "results",
                                  "elementType" : {
-                                    "localId" : "3869",
+                                    "localId" : "4056",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3870",
+                                       "localId" : "4057",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -33215,8 +34834,8 @@
                            "element" : [ {
                               "name" : "modality",
                               "value" : {
-                                 "localId" : "3851",
-                                 "locator" : "656:23-656:46",
+                                 "localId" : "4038",
+                                 "locator" : "695:23-695:46",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "Flexible Sigmoidoscopy",
                                  "type" : "CodeRef"
@@ -33224,49 +34843,49 @@
                            }, {
                               "name" : "results",
                               "value" : {
-                                 "localId" : "3857",
-                                 "locator" : "657:22-657:79",
+                                 "localId" : "4044",
+                                 "locator" : "696:22-696:79",
                                  "name" : "CollateConclusionCodes",
                                  "libraryName" : "CRCSMCommon",
                                  "type" : "FunctionRef",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3863",
+                                    "localId" : "4050",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3864",
+                                       "localId" : "4051",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "signature" : [ {
-                                    "localId" : "3858",
+                                    "localId" : "4045",
                                     "name" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3859",
+                                    "localId" : "4046",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3860",
+                                       "localId" : "4047",
                                        "name" : "{http://hl7.org/fhir}Observation",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3853",
-                                    "locator" : "657:57",
+                                    "localId" : "4040",
+                                    "locator" : "696:57",
                                     "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                                     "name" : "D",
                                     "type" : "AliasRef"
                                  }, {
-                                    "localId" : "3854",
-                                    "locator" : "657:60-657:78",
+                                    "localId" : "4041",
+                                    "locator" : "696:60-696:78",
                                     "name" : "FlexSigObservations",
                                     "type" : "ExpressionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3855",
+                                       "localId" : "4042",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3856",
+                                          "localId" : "4043",
                                           "name" : "{http://hl7.org/fhir}Observation",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -33277,34 +34896,34 @@
                         }
                      } ],
                      "else" : {
-                        "localId" : "3872",
+                        "localId" : "4059",
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "3871",
-                           "locator" : "659:14-659:17",
+                           "localId" : "4058",
+                           "locator" : "698:14-698:17",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "Null"
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "3873",
+                           "localId" : "4060",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3874",
+                              "localId" : "4061",
                               "name" : "modality",
                               "elementType" : {
-                                 "localId" : "3875",
+                                 "localId" : "4062",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3876",
+                              "localId" : "4063",
                               "name" : "results",
                               "elementType" : {
-                                 "localId" : "3877",
+                                 "localId" : "4064",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3878",
+                                    "localId" : "4065",
                                     "name" : "{http://hl7.org/fhir}CodeableConcept",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -33316,8 +34935,8 @@
                }
             }
          }, {
-            "localId" : "3657",
-            "locator" : "620:1-621:67",
+            "localId" : "3844",
+            "locator" : "659:1-660:67",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-MostRecentTestIsColonoscopy",
             "context" : "Patient",
@@ -33325,22 +34944,22 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3657",
+                  "r" : "3844",
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// Most recent colorectal screening/surveillance test\n//------------------------------------------------------------------------------\n\n","define ","\"de-MostRecentTestIsColonoscopy\"",":\n  " ]
                   }, {
-                     "r" : "3658",
+                     "r" : "3845",
                      "s" : [ {
-                        "r" : "3911",
+                        "r" : "4098",
                         "s" : [ {
-                           "r" : "3904",
+                           "r" : "4091",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningTestResults" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3911",
+                           "r" : "4098",
                            "s" : [ {
                               "value" : [ "modality" ]
                            } ]
@@ -33348,7 +34967,7 @@
                      }, {
                         "value" : [ " ","~"," " ]
                      }, {
-                        "r" : "3912",
+                        "r" : "4099",
                         "s" : [ {
                            "value" : [ "\"Colonoscopy\"" ]
                         } ]
@@ -33357,49 +34976,49 @@
                }
             } ],
             "expression" : {
-               "localId" : "3658",
-               "locator" : "621:3-621:67",
+               "localId" : "3845",
+               "locator" : "660:3-660:67",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Equivalent",
                "signature" : [ {
-                  "localId" : "3913",
+                  "localId" : "4100",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3914",
+                  "localId" : "4101",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3911",
-                  "locator" : "621:3-621:51",
+                  "localId" : "4098",
+                  "locator" : "660:3-660:51",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "path" : "modality",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "3904",
-                     "locator" : "621:3-621:42",
+                     "localId" : "4091",
+                     "locator" : "660:3-660:42",
                      "name" : "MostRecentColorectalScreeningTestResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3905",
+                        "localId" : "4092",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3906",
+                           "localId" : "4093",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3907",
+                              "localId" : "4094",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3908",
+                           "localId" : "4095",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3909",
+                              "localId" : "4096",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3910",
+                                 "localId" : "4097",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -33408,16 +35027,16 @@
                      }
                   }
                }, {
-                  "localId" : "3912",
-                  "locator" : "621:55-621:67",
+                  "localId" : "4099",
+                  "locator" : "660:55-660:67",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "name" : "Colonoscopy",
                   "type" : "CodeRef"
                } ]
             }
          }, {
-            "localId" : "3916",
-            "locator" : "623:1-624:71",
+            "localId" : "4103",
+            "locator" : "662:1-663:71",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-MostRecentTestIsCTC",
             "context" : "Patient",
@@ -33425,22 +35044,22 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3916",
+                  "r" : "4103",
                   "s" : [ {
                      "value" : [ "","define ","\"de-MostRecentTestIsCTC\"",":\n  " ]
                   }, {
-                     "r" : "3917",
+                     "r" : "4104",
                      "s" : [ {
-                        "r" : "3925",
+                        "r" : "4112",
                         "s" : [ {
-                           "r" : "3918",
+                           "r" : "4105",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningTestResults" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3925",
+                           "r" : "4112",
                            "s" : [ {
                               "value" : [ "modality" ]
                            } ]
@@ -33448,7 +35067,7 @@
                      }, {
                         "value" : [ " ","~"," " ]
                      }, {
-                        "r" : "3926",
+                        "r" : "4113",
                         "s" : [ {
                            "value" : [ "\"CT Colonography\"" ]
                         } ]
@@ -33457,49 +35076,49 @@
                }
             } ],
             "expression" : {
-               "localId" : "3917",
-               "locator" : "624:3-624:71",
+               "localId" : "4104",
+               "locator" : "663:3-663:71",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Equivalent",
                "signature" : [ {
-                  "localId" : "3927",
+                  "localId" : "4114",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3928",
+                  "localId" : "4115",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3925",
-                  "locator" : "624:3-624:51",
+                  "localId" : "4112",
+                  "locator" : "663:3-663:51",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "path" : "modality",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "3918",
-                     "locator" : "624:3-624:42",
+                     "localId" : "4105",
+                     "locator" : "663:3-663:42",
                      "name" : "MostRecentColorectalScreeningTestResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3919",
+                        "localId" : "4106",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3920",
+                           "localId" : "4107",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3921",
+                              "localId" : "4108",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3922",
+                           "localId" : "4109",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3923",
+                              "localId" : "4110",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3924",
+                                 "localId" : "4111",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -33508,16 +35127,16 @@
                      }
                   }
                }, {
-                  "localId" : "3926",
-                  "locator" : "624:55-624:71",
+                  "localId" : "4113",
+                  "locator" : "663:55-663:71",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "name" : "CT Colonography",
                   "type" : "CodeRef"
                } ]
             }
          }, {
-            "localId" : "3930",
-            "locator" : "626:1-627:78",
+            "localId" : "4117",
+            "locator" : "665:1-666:78",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-MostRecentTestIsFlexSig",
             "context" : "Patient",
@@ -33525,22 +35144,22 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3930",
+                  "r" : "4117",
                   "s" : [ {
                      "value" : [ "","define ","\"de-MostRecentTestIsFlexSig\"",":\n  " ]
                   }, {
-                     "r" : "3931",
+                     "r" : "4118",
                      "s" : [ {
-                        "r" : "3939",
+                        "r" : "4126",
                         "s" : [ {
-                           "r" : "3932",
+                           "r" : "4119",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningTestResults" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3939",
+                           "r" : "4126",
                            "s" : [ {
                               "value" : [ "modality" ]
                            } ]
@@ -33548,7 +35167,7 @@
                      }, {
                         "value" : [ " ","~"," " ]
                      }, {
-                        "r" : "3940",
+                        "r" : "4127",
                         "s" : [ {
                            "value" : [ "\"Flexible Sigmoidoscopy\"" ]
                         } ]
@@ -33557,49 +35176,49 @@
                }
             } ],
             "expression" : {
-               "localId" : "3931",
-               "locator" : "627:3-627:78",
+               "localId" : "4118",
+               "locator" : "666:3-666:78",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Equivalent",
                "signature" : [ {
-                  "localId" : "3941",
+                  "localId" : "4128",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3942",
+                  "localId" : "4129",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3939",
-                  "locator" : "627:3-627:51",
+                  "localId" : "4126",
+                  "locator" : "666:3-666:51",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "path" : "modality",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "3932",
-                     "locator" : "627:3-627:42",
+                     "localId" : "4119",
+                     "locator" : "666:3-666:42",
                      "name" : "MostRecentColorectalScreeningTestResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3933",
+                        "localId" : "4120",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3934",
+                           "localId" : "4121",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3935",
+                              "localId" : "4122",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3936",
+                           "localId" : "4123",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3937",
+                              "localId" : "4124",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3938",
+                                 "localId" : "4125",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -33608,16 +35227,16 @@
                      }
                   }
                }, {
-                  "localId" : "3940",
-                  "locator" : "627:55-627:78",
+                  "localId" : "4127",
+                  "locator" : "666:55-666:78",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "name" : "Flexible Sigmoidoscopy",
                   "type" : "CodeRef"
                } ]
             }
          }, {
-            "localId" : "3944",
-            "locator" : "629:1-630:60",
+            "localId" : "4131",
+            "locator" : "668:1-669:60",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-MostRecentTestIsFOBT",
             "context" : "Patient",
@@ -33625,22 +35244,22 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3944",
+                  "r" : "4131",
                   "s" : [ {
                      "value" : [ "","define ","\"de-MostRecentTestIsFOBT\"",":\n  " ]
                   }, {
-                     "r" : "3945",
+                     "r" : "4132",
                      "s" : [ {
-                        "r" : "3953",
+                        "r" : "4140",
                         "s" : [ {
-                           "r" : "3946",
+                           "r" : "4133",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningTestResults" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3953",
+                           "r" : "4140",
                            "s" : [ {
                               "value" : [ "modality" ]
                            } ]
@@ -33648,7 +35267,7 @@
                      }, {
                         "value" : [ " ","~"," " ]
                      }, {
-                        "r" : "3954",
+                        "r" : "4141",
                         "s" : [ {
                            "value" : [ "\"FOBT\"" ]
                         } ]
@@ -33657,49 +35276,49 @@
                }
             } ],
             "expression" : {
-               "localId" : "3945",
-               "locator" : "630:3-630:60",
+               "localId" : "4132",
+               "locator" : "669:3-669:60",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Equivalent",
                "signature" : [ {
-                  "localId" : "3955",
+                  "localId" : "4142",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3956",
+                  "localId" : "4143",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3953",
-                  "locator" : "630:3-630:51",
+                  "localId" : "4140",
+                  "locator" : "669:3-669:51",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "path" : "modality",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "3946",
-                     "locator" : "630:3-630:42",
+                     "localId" : "4133",
+                     "locator" : "669:3-669:42",
                      "name" : "MostRecentColorectalScreeningTestResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3947",
+                        "localId" : "4134",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3948",
+                           "localId" : "4135",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3949",
+                              "localId" : "4136",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3950",
+                           "localId" : "4137",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3951",
+                              "localId" : "4138",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3952",
+                                 "localId" : "4139",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -33708,16 +35327,16 @@
                      }
                   }
                }, {
-                  "localId" : "3954",
-                  "locator" : "630:55-630:60",
+                  "localId" : "4141",
+                  "locator" : "669:55-669:60",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "name" : "FOBT",
                   "type" : "CodeRef"
                } ]
             }
          }, {
-            "localId" : "3958",
-            "locator" : "632:1-633:64",
+            "localId" : "4145",
+            "locator" : "671:1-672:64",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-MostRecentTestIssDNAFIT",
             "context" : "Patient",
@@ -33725,22 +35344,22 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3958",
+                  "r" : "4145",
                   "s" : [ {
                      "value" : [ "","define ","\"de-MostRecentTestIssDNAFIT\"",":\n  " ]
                   }, {
-                     "r" : "3959",
+                     "r" : "4146",
                      "s" : [ {
-                        "r" : "3967",
+                        "r" : "4154",
                         "s" : [ {
-                           "r" : "3960",
+                           "r" : "4147",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningTestResults" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3967",
+                           "r" : "4154",
                            "s" : [ {
                               "value" : [ "modality" ]
                            } ]
@@ -33748,7 +35367,7 @@
                      }, {
                         "value" : [ " ","~"," " ]
                      }, {
-                        "r" : "3968",
+                        "r" : "4155",
                         "s" : [ {
                            "value" : [ "\"sDNA-FIT\"" ]
                         } ]
@@ -33757,49 +35376,49 @@
                }
             } ],
             "expression" : {
-               "localId" : "3959",
-               "locator" : "633:3-633:64",
+               "localId" : "4146",
+               "locator" : "672:3-672:64",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Equivalent",
                "signature" : [ {
-                  "localId" : "3969",
+                  "localId" : "4156",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "3970",
+                  "localId" : "4157",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3967",
-                  "locator" : "633:3-633:51",
+                  "localId" : "4154",
+                  "locator" : "672:3-672:51",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "path" : "modality",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "3960",
-                     "locator" : "633:3-633:42",
+                     "localId" : "4147",
+                     "locator" : "672:3-672:42",
                      "name" : "MostRecentColorectalScreeningTestResults",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3961",
+                        "localId" : "4148",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3962",
+                           "localId" : "4149",
                            "name" : "modality",
                            "elementType" : {
-                              "localId" : "3963",
+                              "localId" : "4150",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3964",
+                           "localId" : "4151",
                            "name" : "results",
                            "elementType" : {
-                              "localId" : "3965",
+                              "localId" : "4152",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3966",
+                                 "localId" : "4153",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -33808,16 +35427,16 @@
                      }
                   }
                }, {
-                  "localId" : "3968",
-                  "locator" : "633:55-633:64",
+                  "localId" : "4155",
+                  "locator" : "672:55-672:64",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "name" : "sDNA-FIT",
                   "type" : "CodeRef"
                } ]
             }
          }, {
-            "localId" : "3978",
-            "locator" : "662:1-663:76",
+            "localId" : "4165",
+            "locator" : "701:1-702:76",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
             "name" : "MostRecentColorectalScreeningDate",
             "context" : "Patient",
@@ -33825,24 +35444,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3978",
+                  "r" : "4165",
                   "s" : [ {
                      "value" : [ "","define ","MostRecentColorectalScreeningDate",":\n  " ]
                   }, {
-                     "r" : "3981",
+                     "r" : "4168",
                      "s" : [ {
-                        "r" : "3979",
+                        "r" : "4166",
                         "s" : [ {
                            "value" : [ "Common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "3981",
+                        "r" : "4168",
                         "s" : [ {
                            "value" : [ "DiagnosticReportDate","(" ]
                         }, {
-                           "r" : "3980",
+                           "r" : "4167",
                            "s" : [ {
                               "value" : [ "MostRecentColorectalScreeningDiagnosticReport" ]
                            } ]
@@ -33854,28 +35473,28 @@
                }
             } ],
             "expression" : {
-               "localId" : "3981",
-               "locator" : "663:3-663:76",
+               "localId" : "4168",
+               "locator" : "702:3-702:76",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                "name" : "DiagnosticReportDate",
                "libraryName" : "Common",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "3982",
+                  "localId" : "4169",
                   "name" : "{http://hl7.org/fhir}DiagnosticReport",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3980",
-                  "locator" : "663:31-663:75",
+                  "localId" : "4167",
+                  "locator" : "702:31-702:75",
                   "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                   "name" : "MostRecentColorectalScreeningDiagnosticReport",
                   "type" : "ExpressionRef"
                } ]
             }
          }, {
-            "localId" : "3986",
-            "locator" : "684:1-689:7",
+            "localId" : "4173",
+            "locator" : "723:1-728:7",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-FindingPolyps",
             "context" : "Patient",
@@ -33883,20 +35502,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3986",
+                  "r" : "4173",
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// Findings of testing reports\n//------------------------------------------------------------------------------\n\n//TODO Add CollateConclusionCodes function that takes list<FHIR.CodeableConcept> as argument?\n","define ","\"de-FindingPolyps\"",":\n  " ]
                   }, {
-                     "r" : "3987",
+                     "r" : "4174",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "4022",
+                        "r" : "4209",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "3988",
+                              "r" : "4175",
                               "s" : [ {
-                                 "r" : "3990",
+                                 "r" : "4177",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "MostRecentColorectalScreeningTestResults",".","results" ]
@@ -33909,20 +35528,20 @@
                         }, {
                            "value" : [ "\n    " ]
                         }, {
-                           "r" : "4019",
+                           "r" : "4206",
                            "s" : [ {
                               "value" : [ "where " ]
                            }, {
-                              "r" : "4019",
+                              "r" : "4206",
                               "s" : [ {
                                  "value" : [ "AnyTrue","(\n      " ]
                               }, {
-                                 "r" : "4012",
+                                 "r" : "4199",
                                  "s" : [ {
                                     "s" : [ {
-                                       "r" : "3995",
+                                       "r" : "4182",
                                        "s" : [ {
-                                          "r" : "3997",
+                                          "r" : "4184",
                                           "s" : [ {
                                              "s" : [ {
                                                 "value" : [ "R",".","coding" ]
@@ -33935,26 +35554,26 @@
                                  }, {
                                     "value" : [ "\n        " ]
                                  }, {
-                                    "r" : "4002",
+                                    "r" : "4189",
                                     "s" : [ {
                                        "value" : [ "return " ]
                                     }, {
-                                       "r" : "4008",
+                                       "r" : "4195",
                                        "s" : [ {
-                                          "r" : "4005",
+                                          "r" : "4192",
                                           "s" : [ {
-                                             "r" : "4003",
+                                             "r" : "4190",
                                              "s" : [ {
                                                 "value" : [ "FHIRHelpers" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "4005",
+                                             "r" : "4192",
                                              "s" : [ {
                                                 "value" : [ "ToCode","(" ]
                                              }, {
-                                                "r" : "4004",
+                                                "r" : "4191",
                                                 "s" : [ {
                                                    "value" : [ "C" ]
                                                 } ]
@@ -33965,7 +35584,7 @@
                                        }, {
                                           "value" : [ " in " ]
                                        }, {
-                                          "r" : "4007",
+                                          "r" : "4194",
                                           "s" : [ {
                                              "value" : [ "\"Potentially Precancerous Polyp SNOMED\"" ]
                                           } ]
@@ -33982,61 +35601,61 @@
                }
             } ],
             "expression" : {
-               "localId" : "3987",
-               "locator" : "685:3-689:7",
+               "localId" : "4174",
+               "locator" : "724:3-728:7",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "4025",
+                  "localId" : "4212",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4026",
+                     "localId" : "4213",
                      "name" : "{http://hl7.org/fhir}CodeableConcept",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "4022",
-                  "locator" : "685:10-689:7",
+                  "localId" : "4209",
+                  "locator" : "724:10-728:7",
                   "type" : "Query",
                   "resultTypeSpecifier" : {
-                     "localId" : "4023",
+                     "localId" : "4210",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4024",
+                        "localId" : "4211",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "source" : [ {
-                     "localId" : "3988",
-                     "locator" : "685:10-685:59",
+                     "localId" : "4175",
+                     "locator" : "724:10-724:59",
                      "alias" : "R",
                      "resultTypeSpecifier" : {
-                        "localId" : "3993",
+                        "localId" : "4180",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3994",
+                           "localId" : "4181",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "expression" : {
-                        "localId" : "3990",
-                        "locator" : "685:10-685:57",
+                        "localId" : "4177",
+                        "locator" : "724:10-724:57",
                         "path" : "results",
                         "type" : "Property",
                         "resultTypeSpecifier" : {
-                           "localId" : "3991",
+                           "localId" : "4178",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3992",
+                              "localId" : "4179",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : {
-                           "localId" : "3989",
+                           "localId" : "4176",
                            "name" : "MostRecentColorectalScreeningTestResults",
                            "type" : "ExpressionRef"
                         }
@@ -34045,56 +35664,56 @@
                   "let" : [ ],
                   "relationship" : [ ],
                   "where" : {
-                     "localId" : "4019",
-                     "locator" : "686:5-689:7",
+                     "localId" : "4206",
+                     "locator" : "725:5-728:7",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "AnyTrue",
                      "signature" : [ {
-                        "localId" : "4020",
+                        "localId" : "4207",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4021",
+                           "localId" : "4208",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4012",
-                        "locator" : "687:7-688:79",
+                        "localId" : "4199",
+                        "locator" : "726:7-727:79",
                         "type" : "Query",
                         "resultTypeSpecifier" : {
-                           "localId" : "4013",
+                           "localId" : "4200",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4014",
+                              "localId" : "4201",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : [ {
-                           "localId" : "3995",
-                           "locator" : "687:7-687:16",
+                           "localId" : "4182",
+                           "locator" : "726:7-726:16",
                            "alias" : "C",
                            "resultTypeSpecifier" : {
-                              "localId" : "4000",
+                              "localId" : "4187",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4001",
+                                 "localId" : "4188",
                                  "name" : "{http://hl7.org/fhir}Coding",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "3997",
-                              "locator" : "687:7-687:14",
+                              "localId" : "4184",
+                              "locator" : "726:7-726:14",
                               "path" : "coding",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "3998",
+                                 "localId" : "4185",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3999",
+                                    "localId" : "4186",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -34104,50 +35723,50 @@
                         "let" : [ ],
                         "relationship" : [ ],
                         "return" : {
-                           "localId" : "4002",
-                           "locator" : "688:9-688:79",
+                           "localId" : "4189",
+                           "locator" : "727:9-727:79",
                            "resultTypeSpecifier" : {
-                              "localId" : "4010",
+                              "localId" : "4197",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4011",
+                                 "localId" : "4198",
                                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4008",
-                              "locator" : "688:16-688:79",
+                              "localId" : "4195",
+                              "locator" : "727:16-727:79",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "InValueSet",
                               "signature" : [ {
-                                 "localId" : "4009",
+                                 "localId" : "4196",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "code" : {
-                                 "localId" : "4005",
-                                 "locator" : "688:16-688:36",
+                                 "localId" : "4192",
+                                 "locator" : "727:16-727:36",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "ToCode",
                                  "libraryName" : "FHIRHelpers",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "4006",
+                                    "localId" : "4193",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "4004",
-                                    "locator" : "688:35",
+                                    "localId" : "4191",
+                                    "locator" : "727:35",
                                     "resultTypeName" : "{http://hl7.org/fhir}Coding",
                                     "name" : "C",
                                     "type" : "AliasRef"
                                  } ]
                               },
                               "valueset" : {
-                                 "localId" : "4007",
-                                 "locator" : "688:41-688:79",
+                                 "localId" : "4194",
+                                 "locator" : "727:41-727:79",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                                  "name" : "Potentially Precancerous Polyp SNOMED",
                                  "preserve" : true
@@ -34159,8 +35778,8 @@
                }
             }
          }, {
-            "localId" : "4028",
-            "locator" : "691:1-697:9",
+            "localId" : "4215",
+            "locator" : "730:1-736:9",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-FindingCRC",
             "context" : "Patient",
@@ -34168,20 +35787,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4028",
+                  "r" : "4215",
                   "s" : [ {
                      "value" : [ "","define ","\"de-FindingCRC\"",":\n  " ]
                   }, {
-                     "r" : "4029",
+                     "r" : "4216",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "4064",
+                        "r" : "4251",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "4030",
+                              "r" : "4217",
                               "s" : [ {
-                                 "r" : "4032",
+                                 "r" : "4219",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "MostRecentColorectalScreeningTestResults",".","results" ]
@@ -34194,20 +35813,20 @@
                         }, {
                            "value" : [ " \n      " ]
                         }, {
-                           "r" : "4061",
+                           "r" : "4248",
                            "s" : [ {
                               "value" : [ "where\n        " ]
                            }, {
-                              "r" : "4061",
+                              "r" : "4248",
                               "s" : [ {
                                  "value" : [ "AnyTrue","(\n          " ]
                               }, {
-                                 "r" : "4054",
+                                 "r" : "4241",
                                  "s" : [ {
                                     "s" : [ {
-                                       "r" : "4037",
+                                       "r" : "4224",
                                        "s" : [ {
-                                          "r" : "4039",
+                                          "r" : "4226",
                                           "s" : [ {
                                              "s" : [ {
                                                 "value" : [ "R",".","coding" ]
@@ -34220,26 +35839,26 @@
                                  }, {
                                     "value" : [ "\n            " ]
                                  }, {
-                                    "r" : "4044",
+                                    "r" : "4231",
                                     "s" : [ {
                                        "value" : [ "return " ]
                                     }, {
-                                       "r" : "4050",
+                                       "r" : "4237",
                                        "s" : [ {
-                                          "r" : "4047",
+                                          "r" : "4234",
                                           "s" : [ {
-                                             "r" : "4045",
+                                             "r" : "4232",
                                              "s" : [ {
                                                 "value" : [ "FHIRHelpers" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "4047",
+                                             "r" : "4234",
                                              "s" : [ {
                                                 "value" : [ "ToCode","(" ]
                                              }, {
-                                                "r" : "4046",
+                                                "r" : "4233",
                                                 "s" : [ {
                                                    "value" : [ "C" ]
                                                 } ]
@@ -34250,7 +35869,7 @@
                                        }, {
                                           "value" : [ " in " ]
                                        }, {
-                                          "r" : "4049",
+                                          "r" : "4236",
                                           "s" : [ {
                                              "value" : [ "\"Colorectal Cancer SNOMED\"" ]
                                           } ]
@@ -34267,61 +35886,61 @@
                }
             } ],
             "expression" : {
-               "localId" : "4029",
-               "locator" : "692:3-697:9",
+               "localId" : "4216",
+               "locator" : "731:3-736:9",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "4067",
+                  "localId" : "4254",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4068",
+                     "localId" : "4255",
                      "name" : "{http://hl7.org/fhir}CodeableConcept",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "4064",
-                  "locator" : "692:10-697:9",
+                  "localId" : "4251",
+                  "locator" : "731:10-736:9",
                   "type" : "Query",
                   "resultTypeSpecifier" : {
-                     "localId" : "4065",
+                     "localId" : "4252",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4066",
+                        "localId" : "4253",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "source" : [ {
-                     "localId" : "4030",
-                     "locator" : "692:10-692:59",
+                     "localId" : "4217",
+                     "locator" : "731:10-731:59",
                      "alias" : "R",
                      "resultTypeSpecifier" : {
-                        "localId" : "4035",
+                        "localId" : "4222",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4036",
+                           "localId" : "4223",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "expression" : {
-                        "localId" : "4032",
-                        "locator" : "692:10-692:57",
+                        "localId" : "4219",
+                        "locator" : "731:10-731:57",
                         "path" : "results",
                         "type" : "Property",
                         "resultTypeSpecifier" : {
-                           "localId" : "4033",
+                           "localId" : "4220",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4034",
+                              "localId" : "4221",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : {
-                           "localId" : "4031",
+                           "localId" : "4218",
                            "name" : "MostRecentColorectalScreeningTestResults",
                            "type" : "ExpressionRef"
                         }
@@ -34330,56 +35949,56 @@
                   "let" : [ ],
                   "relationship" : [ ],
                   "where" : {
-                     "localId" : "4061",
-                     "locator" : "693:7-697:9",
+                     "localId" : "4248",
+                     "locator" : "732:7-736:9",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "AnyTrue",
                      "signature" : [ {
-                        "localId" : "4062",
+                        "localId" : "4249",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4063",
+                           "localId" : "4250",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4054",
-                        "locator" : "695:11-696:70",
+                        "localId" : "4241",
+                        "locator" : "734:11-735:70",
                         "type" : "Query",
                         "resultTypeSpecifier" : {
-                           "localId" : "4055",
+                           "localId" : "4242",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4056",
+                              "localId" : "4243",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : [ {
-                           "localId" : "4037",
-                           "locator" : "695:11-695:20",
+                           "localId" : "4224",
+                           "locator" : "734:11-734:20",
                            "alias" : "C",
                            "resultTypeSpecifier" : {
-                              "localId" : "4042",
+                              "localId" : "4229",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4043",
+                                 "localId" : "4230",
                                  "name" : "{http://hl7.org/fhir}Coding",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4039",
-                              "locator" : "695:11-695:18",
+                              "localId" : "4226",
+                              "locator" : "734:11-734:18",
                               "path" : "coding",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "4040",
+                                 "localId" : "4227",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4041",
+                                    "localId" : "4228",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -34389,50 +36008,50 @@
                         "let" : [ ],
                         "relationship" : [ ],
                         "return" : {
-                           "localId" : "4044",
-                           "locator" : "696:13-696:70",
+                           "localId" : "4231",
+                           "locator" : "735:13-735:70",
                            "resultTypeSpecifier" : {
-                              "localId" : "4052",
+                              "localId" : "4239",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4053",
+                                 "localId" : "4240",
                                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4050",
-                              "locator" : "696:20-696:70",
+                              "localId" : "4237",
+                              "locator" : "735:20-735:70",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "InValueSet",
                               "signature" : [ {
-                                 "localId" : "4051",
+                                 "localId" : "4238",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "code" : {
-                                 "localId" : "4047",
-                                 "locator" : "696:20-696:40",
+                                 "localId" : "4234",
+                                 "locator" : "735:20-735:40",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "ToCode",
                                  "libraryName" : "FHIRHelpers",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "4048",
+                                    "localId" : "4235",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "4046",
-                                    "locator" : "696:39",
+                                    "localId" : "4233",
+                                    "locator" : "735:39",
                                     "resultTypeName" : "{http://hl7.org/fhir}Coding",
                                     "name" : "C",
                                     "type" : "AliasRef"
                                  } ]
                               },
                               "valueset" : {
-                                 "localId" : "4049",
-                                 "locator" : "696:45-696:70",
+                                 "localId" : "4236",
+                                 "locator" : "735:45-735:70",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                                  "name" : "Colorectal Cancer SNOMED",
                                  "preserve" : true
@@ -34444,8 +36063,8 @@
                }
             }
          }, {
-            "localId" : "4070",
-            "locator" : "699:1-707:8",
+            "localId" : "4257",
+            "locator" : "738:1-746:8",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-CTCInconclusive",
             "context" : "Patient",
@@ -34453,20 +36072,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4070",
+                  "r" : "4257",
                   "s" : [ {
                      "value" : [ "","define ","\"de-CTCInconclusive\"",":\n  " ]
                   }, {
-                     "r" : "4071",
+                     "r" : "4258",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "4112",
+                        "r" : "4299",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "4072",
+                              "r" : "4259",
                               "s" : [ {
-                                 "r" : "4074",
+                                 "r" : "4261",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "MostRecentColorectalScreeningTestResults",".","results" ]
@@ -34479,20 +36098,20 @@
                         }, {
                            "value" : [ "\n    " ]
                         }, {
-                           "r" : "4109",
+                           "r" : "4296",
                            "s" : [ {
                               "value" : [ "where\n      " ]
                            }, {
-                              "r" : "4109",
+                              "r" : "4296",
                               "s" : [ {
                                  "value" : [ "AnyTrue","(\n        " ]
                               }, {
-                                 "r" : "4102",
+                                 "r" : "4289",
                                  "s" : [ {
                                     "s" : [ {
-                                       "r" : "4079",
+                                       "r" : "4266",
                                        "s" : [ {
-                                          "r" : "4081",
+                                          "r" : "4268",
                                           "s" : [ {
                                              "s" : [ {
                                                 "value" : [ "R",".","coding" ]
@@ -34505,26 +36124,26 @@
                                  }, {
                                     "value" : [ "\n          " ]
                                  }, {
-                                    "r" : "4086",
+                                    "r" : "4273",
                                     "s" : [ {
                                        "value" : [ "return " ]
                                     }, {
-                                       "r" : "4096",
+                                       "r" : "4283",
                                        "s" : [ {
-                                          "r" : "4089",
+                                          "r" : "4276",
                                           "s" : [ {
-                                             "r" : "4087",
+                                             "r" : "4274",
                                              "s" : [ {
                                                 "value" : [ "FHIRHelpers" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "4089",
+                                             "r" : "4276",
                                              "s" : [ {
                                                 "value" : [ "ToCode","(" ]
                                              }, {
-                                                "r" : "4088",
+                                                "r" : "4275",
                                                 "s" : [ {
                                                    "value" : [ "C" ]
                                                 } ]
@@ -34535,18 +36154,18 @@
                                        }, {
                                           "value" : [ " in\n            " ]
                                        }, {
-                                          "r" : "4091",
+                                          "r" : "4278",
                                           "s" : [ {
                                              "value" : [ "{" ]
                                           }, {
-                                             "r" : "4092",
+                                             "r" : "4279",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2005 C0\"" ]
                                              } ]
                                           }, {
                                              "value" : [ ",\n            " ]
                                           }, {
-                                             "r" : "4093",
+                                             "r" : "4280",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2023 C0\"" ]
                                              } ]
@@ -34566,61 +36185,61 @@
                }
             } ],
             "expression" : {
-               "localId" : "4071",
-               "locator" : "700:3-707:8",
+               "localId" : "4258",
+               "locator" : "739:3-746:8",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "4115",
+                  "localId" : "4302",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4116",
+                     "localId" : "4303",
                      "name" : "{http://hl7.org/fhir}CodeableConcept",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "4112",
-                  "locator" : "700:10-707:8",
+                  "localId" : "4299",
+                  "locator" : "739:10-746:8",
                   "type" : "Query",
                   "resultTypeSpecifier" : {
-                     "localId" : "4113",
+                     "localId" : "4300",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4114",
+                        "localId" : "4301",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "source" : [ {
-                     "localId" : "4072",
-                     "locator" : "700:10-700:59",
+                     "localId" : "4259",
+                     "locator" : "739:10-739:59",
                      "alias" : "R",
                      "resultTypeSpecifier" : {
-                        "localId" : "4077",
+                        "localId" : "4264",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4078",
+                           "localId" : "4265",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "expression" : {
-                        "localId" : "4074",
-                        "locator" : "700:10-700:57",
+                        "localId" : "4261",
+                        "locator" : "739:10-739:57",
                         "path" : "results",
                         "type" : "Property",
                         "resultTypeSpecifier" : {
-                           "localId" : "4075",
+                           "localId" : "4262",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4076",
+                              "localId" : "4263",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : {
-                           "localId" : "4073",
+                           "localId" : "4260",
                            "name" : "MostRecentColorectalScreeningTestResults",
                            "type" : "ExpressionRef"
                         }
@@ -34629,56 +36248,56 @@
                   "let" : [ ],
                   "relationship" : [ ],
                   "where" : {
-                     "localId" : "4109",
-                     "locator" : "701:5-707:8",
+                     "localId" : "4296",
+                     "locator" : "740:5-746:8",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "AnyTrue",
                      "signature" : [ {
-                        "localId" : "4110",
+                        "localId" : "4297",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4111",
+                           "localId" : "4298",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4102",
-                        "locator" : "703:9-707:7",
+                        "localId" : "4289",
+                        "locator" : "742:9-746:7",
                         "type" : "Query",
                         "resultTypeSpecifier" : {
-                           "localId" : "4103",
+                           "localId" : "4290",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4104",
+                              "localId" : "4291",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : [ {
-                           "localId" : "4079",
-                           "locator" : "703:9-703:18",
+                           "localId" : "4266",
+                           "locator" : "742:9-742:18",
                            "alias" : "C",
                            "resultTypeSpecifier" : {
-                              "localId" : "4084",
+                              "localId" : "4271",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4085",
+                                 "localId" : "4272",
                                  "name" : "{http://hl7.org/fhir}Coding",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4081",
-                              "locator" : "703:9-703:16",
+                              "localId" : "4268",
+                              "locator" : "742:9-742:16",
                               "path" : "coding",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "4082",
+                                 "localId" : "4269",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4083",
+                                    "localId" : "4270",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -34688,76 +36307,76 @@
                         "let" : [ ],
                         "relationship" : [ ],
                         "return" : {
-                           "localId" : "4086",
-                           "locator" : "704:11-707:7",
+                           "localId" : "4273",
+                           "locator" : "743:11-746:7",
                            "resultTypeSpecifier" : {
-                              "localId" : "4100",
+                              "localId" : "4287",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4101",
+                                 "localId" : "4288",
                                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4096",
-                              "locator" : "704:18-707:7",
+                              "localId" : "4283",
+                              "locator" : "743:18-746:7",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "In",
                               "signature" : [ {
-                                 "localId" : "4097",
+                                 "localId" : "4284",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4098",
+                                 "localId" : "4285",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4099",
+                                    "localId" : "4286",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               } ],
                               "operand" : [ {
-                                 "localId" : "4089",
-                                 "locator" : "704:18-704:38",
+                                 "localId" : "4276",
+                                 "locator" : "743:18-743:38",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "ToCode",
                                  "libraryName" : "FHIRHelpers",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "4090",
+                                    "localId" : "4277",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "4088",
-                                    "locator" : "704:37",
+                                    "localId" : "4275",
+                                    "locator" : "743:37",
                                     "resultTypeName" : "{http://hl7.org/fhir}Coding",
                                     "name" : "C",
                                     "type" : "AliasRef"
                                  } ]
                               }, {
-                                 "localId" : "4091",
-                                 "locator" : "705:13-707:7",
+                                 "localId" : "4278",
+                                 "locator" : "744:13-746:7",
                                  "type" : "List",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "4094",
+                                    "localId" : "4281",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4095",
+                                       "localId" : "4282",
                                        "name" : "{urn:hl7-org:elm-types:r1}Code",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "element" : [ {
-                                    "localId" : "4092",
-                                    "locator" : "705:14-705:29",
+                                    "localId" : "4279",
+                                    "locator" : "744:14-744:29",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2005 C0",
                                     "type" : "CodeRef"
                                  }, {
-                                    "localId" : "4093",
-                                    "locator" : "706:13-706:28",
+                                    "localId" : "4280",
+                                    "locator" : "745:13-745:28",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2023 C0",
                                     "type" : "CodeRef"
@@ -34770,8 +36389,8 @@
                }
             }
          }, {
-            "localId" : "4118",
-            "locator" : "709:1-718:8",
+            "localId" : "4305",
+            "locator" : "748:1-757:8",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-CTCFindingPolyps",
             "context" : "Patient",
@@ -34779,20 +36398,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4118",
+                  "r" : "4305",
                   "s" : [ {
                      "value" : [ "","define ","\"de-CTCFindingPolyps\"",":\n  " ]
                   }, {
-                     "r" : "4119",
+                     "r" : "4306",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "4162",
+                        "r" : "4349",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "4120",
+                              "r" : "4307",
                               "s" : [ {
-                                 "r" : "4122",
+                                 "r" : "4309",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "MostRecentColorectalScreeningTestResults",".","results" ]
@@ -34805,20 +36424,20 @@
                         }, {
                            "value" : [ "\n    " ]
                         }, {
-                           "r" : "4159",
+                           "r" : "4346",
                            "s" : [ {
                               "value" : [ "where\n      " ]
                            }, {
-                              "r" : "4159",
+                              "r" : "4346",
                               "s" : [ {
                                  "value" : [ "AnyTrue","(" ]
                               }, {
-                                 "r" : "4152",
+                                 "r" : "4339",
                                  "s" : [ {
                                     "s" : [ {
-                                       "r" : "4127",
+                                       "r" : "4314",
                                        "s" : [ {
-                                          "r" : "4129",
+                                          "r" : "4316",
                                           "s" : [ {
                                              "s" : [ {
                                                 "value" : [ "R",".","coding" ]
@@ -34831,26 +36450,26 @@
                                  }, {
                                     "value" : [ "\n        " ]
                                  }, {
-                                    "r" : "4134",
+                                    "r" : "4321",
                                     "s" : [ {
                                        "value" : [ "return " ]
                                     }, {
-                                       "r" : "4146",
+                                       "r" : "4333",
                                        "s" : [ {
-                                          "r" : "4137",
+                                          "r" : "4324",
                                           "s" : [ {
-                                             "r" : "4135",
+                                             "r" : "4322",
                                              "s" : [ {
                                                 "value" : [ "FHIRHelpers" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "4137",
+                                             "r" : "4324",
                                              "s" : [ {
                                                 "value" : [ "ToCode","(" ]
                                              }, {
-                                                "r" : "4136",
+                                                "r" : "4323",
                                                 "s" : [ {
                                                    "value" : [ "C" ]
                                                 } ]
@@ -34861,32 +36480,32 @@
                                        }, {
                                           "value" : [ " in " ]
                                        }, {
-                                          "r" : "4139",
+                                          "r" : "4326",
                                           "s" : [ {
                                              "value" : [ "{\n          " ]
                                           }, {
-                                             "r" : "4140",
+                                             "r" : "4327",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2005 C2\"" ]
                                              } ]
                                           }, {
                                              "value" : [ ",\n          " ]
                                           }, {
-                                             "r" : "4141",
+                                             "r" : "4328",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2023 C2a\"" ]
                                              } ]
                                           }, {
                                              "value" : [ ",\n          " ]
                                           }, {
-                                             "r" : "4142",
+                                             "r" : "4329",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2005 C3\"" ]
                                              } ]
                                           }, {
                                              "value" : [ ",\n          " ]
                                           }, {
-                                             "r" : "4143",
+                                             "r" : "4330",
                                              "s" : [ {
                                                 "value" : [ "\"C-RADS 2023 C3\"" ]
                                              } ]
@@ -34906,61 +36525,61 @@
                }
             } ],
             "expression" : {
-               "localId" : "4119",
-               "locator" : "710:3-718:8",
+               "localId" : "4306",
+               "locator" : "749:3-757:8",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "4165",
+                  "localId" : "4352",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4166",
+                     "localId" : "4353",
                      "name" : "{http://hl7.org/fhir}CodeableConcept",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "4162",
-                  "locator" : "710:10-718:8",
+                  "localId" : "4349",
+                  "locator" : "749:10-757:8",
                   "type" : "Query",
                   "resultTypeSpecifier" : {
-                     "localId" : "4163",
+                     "localId" : "4350",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4164",
+                        "localId" : "4351",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "source" : [ {
-                     "localId" : "4120",
-                     "locator" : "710:10-710:59",
+                     "localId" : "4307",
+                     "locator" : "749:10-749:59",
                      "alias" : "R",
                      "resultTypeSpecifier" : {
-                        "localId" : "4125",
+                        "localId" : "4312",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4126",
+                           "localId" : "4313",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "expression" : {
-                        "localId" : "4122",
-                        "locator" : "710:10-710:57",
+                        "localId" : "4309",
+                        "locator" : "749:10-749:57",
                         "path" : "results",
                         "type" : "Property",
                         "resultTypeSpecifier" : {
-                           "localId" : "4123",
+                           "localId" : "4310",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4124",
+                              "localId" : "4311",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : {
-                           "localId" : "4121",
+                           "localId" : "4308",
                            "name" : "MostRecentColorectalScreeningTestResults",
                            "type" : "ExpressionRef"
                         }
@@ -34969,56 +36588,56 @@
                   "let" : [ ],
                   "relationship" : [ ],
                   "where" : {
-                     "localId" : "4159",
-                     "locator" : "711:5-718:8",
+                     "localId" : "4346",
+                     "locator" : "750:5-757:8",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "AnyTrue",
                      "signature" : [ {
-                        "localId" : "4160",
+                        "localId" : "4347",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4161",
+                           "localId" : "4348",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4152",
-                        "locator" : "712:15-718:7",
+                        "localId" : "4339",
+                        "locator" : "751:15-757:7",
                         "type" : "Query",
                         "resultTypeSpecifier" : {
-                           "localId" : "4153",
+                           "localId" : "4340",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4154",
+                              "localId" : "4341",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : [ {
-                           "localId" : "4127",
-                           "locator" : "712:15-712:24",
+                           "localId" : "4314",
+                           "locator" : "751:15-751:24",
                            "alias" : "C",
                            "resultTypeSpecifier" : {
-                              "localId" : "4132",
+                              "localId" : "4319",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4133",
+                                 "localId" : "4320",
                                  "name" : "{http://hl7.org/fhir}Coding",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4129",
-                              "locator" : "712:15-712:22",
+                              "localId" : "4316",
+                              "locator" : "751:15-751:22",
                               "path" : "coding",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "4130",
+                                 "localId" : "4317",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4131",
+                                    "localId" : "4318",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -35028,88 +36647,88 @@
                         "let" : [ ],
                         "relationship" : [ ],
                         "return" : {
-                           "localId" : "4134",
-                           "locator" : "713:9-718:7",
+                           "localId" : "4321",
+                           "locator" : "752:9-757:7",
                            "resultTypeSpecifier" : {
-                              "localId" : "4150",
+                              "localId" : "4337",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4151",
+                                 "localId" : "4338",
                                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4146",
-                              "locator" : "713:16-718:7",
+                              "localId" : "4333",
+                              "locator" : "752:16-757:7",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "In",
                               "signature" : [ {
-                                 "localId" : "4147",
+                                 "localId" : "4334",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4148",
+                                 "localId" : "4335",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4149",
+                                    "localId" : "4336",
                                     "name" : "{urn:hl7-org:elm-types:r1}Code",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               } ],
                               "operand" : [ {
-                                 "localId" : "4137",
-                                 "locator" : "713:16-713:36",
+                                 "localId" : "4324",
+                                 "locator" : "752:16-752:36",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "ToCode",
                                  "libraryName" : "FHIRHelpers",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "4138",
+                                    "localId" : "4325",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "4136",
-                                    "locator" : "713:35",
+                                    "localId" : "4323",
+                                    "locator" : "752:35",
                                     "resultTypeName" : "{http://hl7.org/fhir}Coding",
                                     "name" : "C",
                                     "type" : "AliasRef"
                                  } ]
                               }, {
-                                 "localId" : "4139",
-                                 "locator" : "713:41-718:7",
+                                 "localId" : "4326",
+                                 "locator" : "752:41-757:7",
                                  "type" : "List",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "4144",
+                                    "localId" : "4331",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4145",
+                                       "localId" : "4332",
                                        "name" : "{urn:hl7-org:elm-types:r1}Code",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  },
                                  "element" : [ {
-                                    "localId" : "4140",
-                                    "locator" : "714:11-714:26",
+                                    "localId" : "4327",
+                                    "locator" : "753:11-753:26",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2005 C2",
                                     "type" : "CodeRef"
                                  }, {
-                                    "localId" : "4141",
-                                    "locator" : "715:11-715:27",
+                                    "localId" : "4328",
+                                    "locator" : "754:11-754:27",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2023 C2a",
                                     "type" : "CodeRef"
                                  }, {
-                                    "localId" : "4142",
-                                    "locator" : "716:11-716:26",
+                                    "localId" : "4329",
+                                    "locator" : "755:11-755:26",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2005 C3",
                                     "type" : "CodeRef"
                                  }, {
-                                    "localId" : "4143",
-                                    "locator" : "717:11-717:26",
+                                    "localId" : "4330",
+                                    "locator" : "756:11-756:26",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                     "name" : "C-RADS 2023 C3",
                                     "type" : "CodeRef"
@@ -35122,8 +36741,8 @@
                }
             }
          }, {
-            "localId" : "4168",
-            "locator" : "720:1-725:9",
+            "localId" : "4355",
+            "locator" : "759:1-764:9",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-CTCFindingCRC",
             "context" : "Patient",
@@ -35131,20 +36750,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4168",
+                  "r" : "4355",
                   "s" : [ {
                      "value" : [ "","define ","\"de-CTCFindingCRC\"",":\n  " ]
                   }, {
-                     "r" : "4169",
+                     "r" : "4356",
                      "s" : [ {
                         "value" : [ "exists " ]
                      }, {
-                        "r" : "4205",
+                        "r" : "4392",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "4170",
+                              "r" : "4357",
                               "s" : [ {
-                                 "r" : "4172",
+                                 "r" : "4359",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "MostRecentColorectalScreeningTestResults",".","results" ]
@@ -35157,20 +36776,20 @@
                         }, {
                            "value" : [ "\n    " ]
                         }, {
-                           "r" : "4202",
+                           "r" : "4389",
                            "s" : [ {
                               "value" : [ "where\n      " ]
                            }, {
-                              "r" : "4202",
+                              "r" : "4389",
                               "s" : [ {
                                  "value" : [ "AnyTrue","(" ]
                               }, {
-                                 "r" : "4195",
+                                 "r" : "4382",
                                  "s" : [ {
                                     "s" : [ {
-                                       "r" : "4177",
+                                       "r" : "4364",
                                        "s" : [ {
-                                          "r" : "4179",
+                                          "r" : "4366",
                                           "s" : [ {
                                              "s" : [ {
                                                 "value" : [ "R",".","coding" ]
@@ -35183,26 +36802,26 @@
                                  }, {
                                     "value" : [ "\n        " ]
                                  }, {
-                                    "r" : "4184",
+                                    "r" : "4371",
                                     "s" : [ {
                                        "value" : [ "return " ]
                                     }, {
-                                       "r" : "4185",
+                                       "r" : "4372",
                                        "s" : [ {
-                                          "r" : "4188",
+                                          "r" : "4375",
                                           "s" : [ {
-                                             "r" : "4186",
+                                             "r" : "4373",
                                              "s" : [ {
                                                 "value" : [ "FHIRHelpers" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "4188",
+                                             "r" : "4375",
                                              "s" : [ {
                                                 "value" : [ "ToCode","(" ]
                                              }, {
-                                                "r" : "4187",
+                                                "r" : "4374",
                                                 "s" : [ {
                                                    "value" : [ "C" ]
                                                 } ]
@@ -35213,7 +36832,7 @@
                                        }, {
                                           "value" : [ " ","~"," " ]
                                        }, {
-                                          "r" : "4190",
+                                          "r" : "4377",
                                           "s" : [ {
                                              "value" : [ "\"C-RADS 2023 C4\"" ]
                                           } ]
@@ -35230,61 +36849,61 @@
                }
             } ],
             "expression" : {
-               "localId" : "4169",
-               "locator" : "721:3-725:9",
+               "localId" : "4356",
+               "locator" : "760:3-764:9",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Exists",
                "signature" : [ {
-                  "localId" : "4208",
+                  "localId" : "4395",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4209",
+                     "localId" : "4396",
                      "name" : "{http://hl7.org/fhir}CodeableConcept",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : {
-                  "localId" : "4205",
-                  "locator" : "721:10-725:9",
+                  "localId" : "4392",
+                  "locator" : "760:10-764:9",
                   "type" : "Query",
                   "resultTypeSpecifier" : {
-                     "localId" : "4206",
+                     "localId" : "4393",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4207",
+                        "localId" : "4394",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "source" : [ {
-                     "localId" : "4170",
-                     "locator" : "721:10-721:59",
+                     "localId" : "4357",
+                     "locator" : "760:10-760:59",
                      "alias" : "R",
                      "resultTypeSpecifier" : {
-                        "localId" : "4175",
+                        "localId" : "4362",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4176",
+                           "localId" : "4363",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "expression" : {
-                        "localId" : "4172",
-                        "locator" : "721:10-721:57",
+                        "localId" : "4359",
+                        "locator" : "760:10-760:57",
                         "path" : "results",
                         "type" : "Property",
                         "resultTypeSpecifier" : {
-                           "localId" : "4173",
+                           "localId" : "4360",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4174",
+                              "localId" : "4361",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : {
-                           "localId" : "4171",
+                           "localId" : "4358",
                            "name" : "MostRecentColorectalScreeningTestResults",
                            "type" : "ExpressionRef"
                         }
@@ -35293,56 +36912,56 @@
                   "let" : [ ],
                   "relationship" : [ ],
                   "where" : {
-                     "localId" : "4202",
-                     "locator" : "722:5-725:9",
+                     "localId" : "4389",
+                     "locator" : "761:5-764:9",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "AnyTrue",
                      "signature" : [ {
-                        "localId" : "4203",
+                        "localId" : "4390",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4204",
+                           "localId" : "4391",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4195",
-                        "locator" : "723:15-724:55",
+                        "localId" : "4382",
+                        "locator" : "762:15-763:55",
                         "type" : "Query",
                         "resultTypeSpecifier" : {
-                           "localId" : "4196",
+                           "localId" : "4383",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4197",
+                              "localId" : "4384",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "source" : [ {
-                           "localId" : "4177",
-                           "locator" : "723:15-723:24",
+                           "localId" : "4364",
+                           "locator" : "762:15-762:24",
                            "alias" : "C",
                            "resultTypeSpecifier" : {
-                              "localId" : "4182",
+                              "localId" : "4369",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4183",
+                                 "localId" : "4370",
                                  "name" : "{http://hl7.org/fhir}Coding",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4179",
-                              "locator" : "723:15-723:22",
+                              "localId" : "4366",
+                              "locator" : "762:15-762:22",
                               "path" : "coding",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "4180",
+                                 "localId" : "4367",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4181",
+                                    "localId" : "4368",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -35352,53 +36971,53 @@
                         "let" : [ ],
                         "relationship" : [ ],
                         "return" : {
-                           "localId" : "4184",
-                           "locator" : "724:9-724:55",
+                           "localId" : "4371",
+                           "locator" : "763:9-763:55",
                            "resultTypeSpecifier" : {
-                              "localId" : "4193",
+                              "localId" : "4380",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4194",
+                                 "localId" : "4381",
                                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "expression" : {
-                              "localId" : "4185",
-                              "locator" : "724:16-724:55",
+                              "localId" : "4372",
+                              "locator" : "763:16-763:55",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "Equivalent",
                               "signature" : [ {
-                                 "localId" : "4191",
+                                 "localId" : "4378",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4192",
+                                 "localId" : "4379",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "4188",
-                                 "locator" : "724:16-724:36",
+                                 "localId" : "4375",
+                                 "locator" : "763:16-763:36",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "ToCode",
                                  "libraryName" : "FHIRHelpers",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "4189",
+                                    "localId" : "4376",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "4187",
-                                    "locator" : "724:35",
+                                    "localId" : "4374",
+                                    "locator" : "763:35",
                                     "resultTypeName" : "{http://hl7.org/fhir}Coding",
                                     "name" : "C",
                                     "type" : "AliasRef"
                                  } ]
                               }, {
-                                 "localId" : "4190",
-                                 "locator" : "724:40-724:55",
+                                 "localId" : "4377",
+                                 "locator" : "763:40-763:55",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                                  "name" : "C-RADS 2023 C4",
                                  "type" : "CodeRef"
@@ -35410,8 +37029,8 @@
                }
             }
          }, {
-            "localId" : "4213",
-            "locator" : "730:1-732:82",
+            "localId" : "4400",
+            "locator" : "769:1-771:82",
             "resultTypeName" : "{http://hl7.org/fhir}Quantity",
             "name" : "FollowUpIntervalFromEndoscopist",
             "context" : "Patient",
@@ -35419,16 +37038,16 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4213",
+                  "r" : "4400",
                   "s" : [ {
                      "value" : [ "","define ","FollowUpIntervalFromEndoscopist",":\n  " ]
                   }, {
-                     "r" : "4237",
+                     "r" : "4424",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "4214",
+                           "r" : "4401",
                            "s" : [ {
-                              "r" : "4215",
+                              "r" : "4402",
                               "s" : [ {
                                  "s" : [ {
                                     "value" : [ "MostRecentColorectalScreeningDiagnosticReport" ]
@@ -35441,35 +37060,35 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "4216",
+                        "r" : "4403",
                         "s" : [ {
                            "value" : [ "return " ]
                         }, {
-                           "r" : "4234",
+                           "r" : "4421",
                            "s" : [ {
                               "value" : [ "First","(" ]
                            }, {
-                              "r" : "4222",
+                              "r" : "4409",
                               "s" : [ {
-                                 "r" : "4217",
+                                 "r" : "4404",
                                  "s" : [ {
                                     "value" : [ "CRCSMCommon" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "4222",
+                                 "r" : "4409",
                                  "s" : [ {
                                     "value" : [ "ValueQuantityFromObservation","(" ]
                                  }, {
-                                    "r" : "4218",
+                                    "r" : "4405",
                                     "s" : [ {
                                        "value" : [ "D" ]
                                     } ]
                                  }, {
                                     "value" : [ "," ]
                                  }, {
-                                    "r" : "4219",
+                                    "r" : "4406",
                                     "s" : [ {
                                        "value" : [ "FollowUpObservations" ]
                                     } ]
@@ -35486,18 +37105,18 @@
                }
             } ],
             "expression" : {
-               "localId" : "4237",
-               "locator" : "731:3-732:82",
+               "localId" : "4424",
+               "locator" : "770:3-771:82",
                "resultTypeName" : "{http://hl7.org/fhir}Quantity",
                "type" : "Query",
                "source" : [ {
-                  "localId" : "4214",
-                  "locator" : "731:3-731:49",
+                  "localId" : "4401",
+                  "locator" : "770:3-770:49",
                   "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                   "alias" : "D",
                   "expression" : {
-                     "localId" : "4215",
-                     "locator" : "731:3-731:47",
+                     "localId" : "4402",
+                     "locator" : "770:3-770:47",
                      "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                      "name" : "MostRecentColorectalScreeningDiagnosticReport",
                      "type" : "ExpressionRef"
@@ -35506,67 +37125,67 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "4216",
-                  "locator" : "732:5-732:82",
+                  "localId" : "4403",
+                  "locator" : "771:5-771:82",
                   "resultTypeName" : "{http://hl7.org/fhir}Quantity",
                   "expression" : {
-                     "localId" : "4234",
-                     "locator" : "732:12-732:82",
+                     "localId" : "4421",
+                     "locator" : "771:12-771:82",
                      "resultTypeName" : "{http://hl7.org/fhir}Quantity",
                      "type" : "First",
                      "signature" : [ {
-                        "localId" : "4235",
+                        "localId" : "4422",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4236",
+                           "localId" : "4423",
                            "name" : "{http://hl7.org/fhir}Quantity",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "source" : {
-                        "localId" : "4222",
-                        "locator" : "732:18-732:81",
+                        "localId" : "4409",
+                        "locator" : "771:18-771:81",
                         "name" : "ValueQuantityFromObservation",
                         "libraryName" : "CRCSMCommon",
                         "type" : "FunctionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "4228",
+                           "localId" : "4415",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4229",
+                              "localId" : "4416",
                               "name" : "{http://hl7.org/fhir}Quantity",
                               "type" : "NamedTypeSpecifier"
                            }
                         },
                         "signature" : [ {
-                           "localId" : "4223",
+                           "localId" : "4410",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }, {
-                           "localId" : "4224",
+                           "localId" : "4411",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4225",
+                              "localId" : "4412",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "4218",
-                           "locator" : "732:59",
+                           "localId" : "4405",
+                           "locator" : "771:59",
                            "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                            "name" : "D",
                            "type" : "AliasRef"
                         }, {
-                           "localId" : "4219",
-                           "locator" : "732:61-732:80",
+                           "localId" : "4406",
+                           "locator" : "771:61-771:80",
                            "name" : "FollowUpObservations",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "4220",
+                              "localId" : "4407",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4221",
+                                 "localId" : "4408",
                                  "name" : "{http://hl7.org/fhir}Observation",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -35577,8 +37196,8 @@
                }
             }
          }, {
-            "localId" : "4211",
-            "locator" : "727:1-728:45",
+            "localId" : "4398",
+            "locator" : "766:1-767:45",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "de-RecommendedInterval",
             "context" : "Patient",
@@ -35586,13 +37205,13 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "4211",
+                  "r" : "4398",
                   "s" : [ {
                      "value" : [ "","define ","\"de-RecommendedInterval\"",":\n  " ]
                   }, {
-                     "r" : "4241",
+                     "r" : "4428",
                      "s" : [ {
-                        "r" : "4238",
+                        "r" : "4425",
                         "s" : [ {
                            "value" : [ "FollowUpIntervalFromEndoscopist" ]
                         } ]
@@ -35603,28 +37222,28 @@
                }
             } ],
             "expression" : {
-               "localId" : "4241",
-               "locator" : "728:3-728:45",
+               "localId" : "4428",
+               "locator" : "767:3-767:45",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "Not",
                "signature" : [ {
-                  "localId" : "4242",
+                  "localId" : "4429",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : {
-                  "localId" : "4239",
-                  "locator" : "728:3-728:45",
+                  "localId" : "4426",
+                  "locator" : "767:3-767:45",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "IsNull",
                   "signature" : [ {
-                     "localId" : "4240",
+                     "localId" : "4427",
                      "name" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : {
-                     "localId" : "4238",
-                     "locator" : "728:3-728:33",
+                     "localId" : "4425",
+                     "locator" : "767:3-767:33",
                      "resultTypeName" : "{http://hl7.org/fhir}Quantity",
                      "name" : "FollowUpIntervalFromEndoscopist",
                      "type" : "ExpressionRef"

--- a/src/services/cql/crc/PertinentHistory.cql
+++ b/src/services/cql/crc/PertinentHistory.cql
@@ -348,7 +348,16 @@ define function FormatReports(DrList List<DiagnosticReport>, ObsList List<Observ
   return {
     name: ReportType,
     longName: Common.ConceptText(D.code),
-    value: CollatedCodes, //TODO: what to return for report value??
+    value: First(flatten(
+      (CollatedCodes) cC
+        return (cC.coding) cCC
+          return cCC.display
+    )),
+    longValue: flatten(
+      (CollatedCodes) cC
+        return (cC.coding) cCC
+          return cCC.display
+    ),
     date: Common.DiagnosticReportDateString(D),
     reference: 'DiagnosticReport/' + D.id,
     edited: HasBeenLocallyEdited(D)

--- a/src/services/cql/crc/PertinentHistory.json
+++ b/src/services/cql/crc/PertinentHistory.json
@@ -9,7 +9,7 @@
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "3458",
+            "r" : "3626",
             "s" : [ {
                "value" : [ "/*  \n  Author: CMS Alliance to Modernize Healthcare, operated by THE MITRE Corporation.\n\n  (C) 2025 The MITRE Corporation. All Rights Reserved. \n  Approved for Public Release: 24-2711. \n  Distribution Unlimited.\n\n  Unless otherwise noted, this work is available under an Apache 2.0 license. \n  It was produced by the MITRE Corporation for the Division of Cancer Prevention \n  and Control, Centers for Disease Control and Prevention in accordance with the \n  Statement of Work, contract number 75FCMC18D0047, task order number 75D30123F17931.\n*/\n\n","library PertinentHistory version '1.0.0'" ]
             } ]
@@ -307,10 +307,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4495",
+               "localId" : "4669",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4496",
+                  "localId" : "4670",
                   "name" : "{http://hl7.org/fhir}HumanName",
                   "type" : "NamedTypeSpecifier"
                }
@@ -441,26 +441,26 @@
                   "s" : [ {
                      "value" : [ "","define function FormatPatientName(name FHIR.HumanName):\n  " ]
                   }, {
-                     "r" : "4526",
+                     "r" : "4700",
                      "s" : [ {
-                        "r" : "4526",
+                        "r" : "4700",
                         "s" : [ {
-                           "r" : "4519",
+                           "r" : "4693",
                            "s" : [ {
-                              "r" : "4511",
+                              "r" : "4685",
                               "s" : [ {
                                  "value" : [ "First","(" ]
                               }, {
-                                 "r" : "4502",
+                                 "r" : "4676",
                                  "s" : [ {
-                                    "r" : "4501",
+                                    "r" : "4675",
                                     "s" : [ {
                                        "value" : [ "name" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "4502",
+                                    "r" : "4676",
                                     "s" : [ {
                                        "value" : [ "given" ]
                                     } ]
@@ -471,7 +471,7 @@
                            }, {
                               "value" : [ " + " ]
                            }, {
-                              "r" : "4514",
+                              "r" : "4688",
                               "s" : [ {
                                  "value" : [ "' '" ]
                               } ]
@@ -479,16 +479,16 @@
                         }, {
                            "value" : [ " + " ]
                         }, {
-                           "r" : "4521",
+                           "r" : "4695",
                            "s" : [ {
-                              "r" : "4520",
+                              "r" : "4694",
                               "s" : [ {
                                  "value" : [ "name" ]
                               } ]
                            }, {
                               "value" : [ "." ]
                            }, {
-                              "r" : "4521",
+                              "r" : "4695",
                               "s" : [ {
                                  "value" : [ "family" ]
                               } ]
@@ -499,57 +499,57 @@
                }
             } ],
             "expression" : {
-               "localId" : "4526",
+               "localId" : "4700",
                "locator" : "76:3-76:39",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                "type" : "Concatenate",
                "signature" : [ ],
                "operand" : [ {
-                  "localId" : "4519",
+                  "localId" : "4693",
                   "locator" : "76:3-76:25",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "Concatenate",
                   "signature" : [ ],
                   "operand" : [ {
-                     "localId" : "4515",
+                     "localId" : "4689",
                      "name" : "ToString",
                      "libraryName" : "FHIRHelpers",
                      "type" : "FunctionRef",
                      "signature" : [ {
-                        "localId" : "4516",
+                        "localId" : "4690",
                         "name" : "{http://hl7.org/fhir}string",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4511",
+                        "localId" : "4685",
                         "locator" : "76:3-76:19",
                         "resultTypeName" : "{http://hl7.org/fhir}string",
                         "type" : "First",
                         "signature" : [ {
-                           "localId" : "4512",
+                           "localId" : "4686",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4513",
+                              "localId" : "4687",
                               "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "source" : {
-                           "localId" : "4502",
+                           "localId" : "4676",
                            "locator" : "76:9-76:18",
                            "path" : "given",
                            "type" : "Property",
                            "resultTypeSpecifier" : {
-                              "localId" : "4505",
+                              "localId" : "4679",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4506",
+                                 "localId" : "4680",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "source" : {
-                              "localId" : "4501",
+                              "localId" : "4675",
                               "locator" : "76:9-76:12",
                               "resultTypeName" : "{http://hl7.org/fhir}HumanName",
                               "name" : "name",
@@ -558,7 +558,7 @@
                         }
                      } ]
                   }, {
-                     "localId" : "4514",
+                     "localId" : "4688",
                      "locator" : "76:23-76:25",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -566,23 +566,23 @@
                      "type" : "Literal"
                   } ]
                }, {
-                  "localId" : "4522",
+                  "localId" : "4696",
                   "name" : "ToString",
                   "libraryName" : "FHIRHelpers",
                   "type" : "FunctionRef",
                   "signature" : [ {
-                     "localId" : "4523",
+                     "localId" : "4697",
                      "name" : "{http://hl7.org/fhir}string",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "4521",
+                     "localId" : "4695",
                      "locator" : "76:29-76:39",
                      "resultTypeName" : "{http://hl7.org/fhir}string",
                      "path" : "family",
                      "type" : "Property",
                      "source" : {
-                        "localId" : "4520",
+                        "localId" : "4694",
                         "locator" : "76:29-76:32",
                         "resultTypeName" : "{http://hl7.org/fhir}HumanName",
                         "name" : "name",
@@ -679,10 +679,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4497",
+               "localId" : "4671",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4498",
+                  "localId" : "4672",
                   "name" : "{http://hl7.org/fhir}HumanName",
                   "type" : "NamedTypeSpecifier"
                }
@@ -3268,13 +3268,13 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4527",
+               "localId" : "4701",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4528",
+                  "localId" : "4702",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4529",
+                     "localId" : "4703",
                      "name" : "{urn:hl7-org:elm-types:r1}String",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -4031,13 +4031,13 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4530",
+               "localId" : "4704",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4531",
+                  "localId" : "4705",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4532",
+                     "localId" : "4706",
                      "name" : "{urn:hl7-org:elm-types:r1}String",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -4865,10 +4865,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4533",
+               "localId" : "4707",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4534",
+                  "localId" : "4708",
                   "name" : "{http://hl7.org/fhir}Condition",
                   "type" : "NamedTypeSpecifier"
                }
@@ -5405,14 +5405,14 @@
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// FUNCTIONS\n//------------------------------------------------------------------------------\n\n","define function HasBeenLocallyEdited(R FHIR.DomainResource):\n  " ]
                   }, {
-                     "r" : "4902",
+                     "r" : "5088",
                      "s" : [ {
-                        "r" : "4902",
+                        "r" : "5088",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "4772",
+                              "r" : "4958",
                               "s" : [ {
-                                 "r" : "4774",
+                                 "r" : "4960",
                                  "s" : [ {
                                     "s" : [ {
                                        "value" : [ "R",".","extension" ]
@@ -5425,24 +5425,24 @@
                         }, {
                            "value" : [ "\n    " ]
                         }, {
-                           "r" : "4779",
+                           "r" : "4965",
                            "s" : [ {
                               "value" : [ "where\n      " ]
                            }, {
-                              "r" : "4779",
+                              "r" : "4965",
                               "s" : [ {
-                                 "r" : "4780",
+                                 "r" : "4966",
                                  "s" : [ {
-                                    "r" : "4782",
+                                    "r" : "4968",
                                     "s" : [ {
-                                       "r" : "4781",
+                                       "r" : "4967",
                                        "s" : [ {
                                           "value" : [ "ext" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "4782",
+                                       "r" : "4968",
                                        "s" : [ {
                                           "value" : [ "url" ]
                                        } ]
@@ -5450,7 +5450,7 @@
                                  }, {
                                     "value" : [ " ","="," " ]
                                  }, {
-                                    "r" : "4783",
+                                    "r" : "4969",
                                     "s" : [ {
                                        "value" : [ "'http://cancerscreeningcds.github.io/crcsm-cds/StructureDefinition/crcsm-edited'" ]
                                     } ]
@@ -5458,20 +5458,20 @@
                               }, {
                                  "value" : [ "\n      and " ]
                               }, {
-                                 "r" : "4788",
+                                 "r" : "4974",
                                  "s" : [ {
-                                    "r" : "4789",
+                                    "r" : "4975",
                                     "s" : [ {
-                                       "r" : "4791",
+                                       "r" : "4977",
                                        "s" : [ {
-                                          "r" : "4790",
+                                          "r" : "4976",
                                           "s" : [ {
                                              "value" : [ "ext" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "4791",
+                                          "r" : "4977",
                                           "s" : [ {
                                              "value" : [ "value" ]
                                           } ]
@@ -5479,13 +5479,13 @@
                                     }, {
                                        "value" : [ " as " ]
                                     }, {
-                                       "r" : "4894",
+                                       "r" : "5080",
                                        "s" : [ {
                                           "value" : [ "FHIR",".","boolean" ]
                                        } ]
                                     } ]
                                  }, {
-                                    "r" : "4895",
+                                    "r" : "5081",
                                     "value" : [ " ","="," ","true" ]
                                  } ]
                               } ]
@@ -5496,56 +5496,56 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4907",
+               "localId" : "5093",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4908",
+                  "localId" : "5094",
                   "name" : "{http://hl7.org/fhir}Extension",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "4902",
+               "localId" : "5088",
                "locator" : "332:3-335:42",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "4905",
+                  "localId" : "5091",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4906",
+                     "localId" : "5092",
                      "name" : "{http://hl7.org/fhir}Extension",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "source" : [ {
-                  "localId" : "4772",
+                  "localId" : "4958",
                   "locator" : "332:3-332:17",
                   "alias" : "ext",
                   "resultTypeSpecifier" : {
-                     "localId" : "4777",
+                     "localId" : "4963",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4778",
+                        "localId" : "4964",
                         "name" : "{http://hl7.org/fhir}Extension",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "4774",
+                     "localId" : "4960",
                      "locator" : "332:3-332:13",
                      "path" : "extension",
                      "type" : "Property",
                      "resultTypeSpecifier" : {
-                        "localId" : "4775",
+                        "localId" : "4961",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4776",
+                           "localId" : "4962",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "source" : {
-                        "localId" : "4773",
+                        "localId" : "4959",
                         "name" : "R",
                         "type" : "OperandRef"
                      }
@@ -5554,45 +5554,45 @@
                "let" : [ ],
                "relationship" : [ ],
                "where" : {
-                  "localId" : "4779",
+                  "localId" : "4965",
                   "locator" : "333:5-335:42",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "And",
                   "signature" : [ {
-                     "localId" : "4900",
+                     "localId" : "5086",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "4901",
+                     "localId" : "5087",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "4780",
+                     "localId" : "4966",
                      "locator" : "334:7-334:96",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Equal",
                      "signature" : [ {
-                        "localId" : "4786",
+                        "localId" : "4972",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "4787",
+                        "localId" : "4973",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4784",
+                        "localId" : "4970",
                         "name" : "ToString",
                         "libraryName" : "FHIRHelpers",
                         "type" : "FunctionRef",
                         "signature" : [ {
-                           "localId" : "4785",
+                           "localId" : "4971",
                            "name" : "{http://hl7.org/fhir}uri",
                            "type" : "NamedTypeSpecifier"
                         } ],
                         "operand" : [ {
-                           "localId" : "4782",
+                           "localId" : "4968",
                            "locator" : "334:7-334:13",
                            "resultTypeName" : "{http://hl7.org/fhir}uri",
                            "path" : "url",
@@ -5600,7 +5600,7 @@
                            "type" : "Property"
                         } ]
                      }, {
-                        "localId" : "4783",
+                        "localId" : "4969",
                         "locator" : "334:17-334:96",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -5608,251 +5608,251 @@
                         "type" : "Literal"
                      } ]
                   }, {
-                     "localId" : "4788",
+                     "localId" : "4974",
                      "locator" : "335:11-335:42",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "Equal",
                      "signature" : [ {
-                        "localId" : "4898",
+                        "localId" : "5084",
                         "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "4899",
+                        "localId" : "5085",
                         "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4896",
+                        "localId" : "5082",
                         "name" : "ToBoolean",
                         "libraryName" : "FHIRHelpers",
                         "type" : "FunctionRef",
                         "signature" : [ {
-                           "localId" : "4897",
+                           "localId" : "5083",
                            "name" : "{http://hl7.org/fhir}boolean",
                            "type" : "NamedTypeSpecifier"
                         } ],
                         "operand" : [ {
-                           "localId" : "4789",
+                           "localId" : "4975",
                            "locator" : "335:11-335:35",
                            "resultTypeName" : "{http://hl7.org/fhir}boolean",
                            "strict" : false,
                            "type" : "As",
                            "signature" : [ ],
                            "operand" : {
-                              "localId" : "4791",
+                              "localId" : "4977",
                               "locator" : "335:11-335:19",
                               "path" : "value",
                               "scope" : "ext",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "4843",
+                                 "localId" : "5029",
                                  "type" : "ChoiceTypeSpecifier",
                                  "type" : [ ],
                                  "choice" : [ {
-                                    "localId" : "4844",
+                                    "localId" : "5030",
                                     "name" : "{http://hl7.org/fhir}base64Binary",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4845",
+                                    "localId" : "5031",
                                     "name" : "{http://hl7.org/fhir}boolean",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4846",
+                                    "localId" : "5032",
                                     "name" : "{http://hl7.org/fhir}canonical",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4847",
+                                    "localId" : "5033",
                                     "name" : "{http://hl7.org/fhir}code",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4848",
+                                    "localId" : "5034",
                                     "name" : "{http://hl7.org/fhir}date",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4849",
+                                    "localId" : "5035",
                                     "name" : "{http://hl7.org/fhir}dateTime",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4850",
+                                    "localId" : "5036",
                                     "name" : "{http://hl7.org/fhir}decimal",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4851",
+                                    "localId" : "5037",
                                     "name" : "{http://hl7.org/fhir}id",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4852",
+                                    "localId" : "5038",
                                     "name" : "{http://hl7.org/fhir}instant",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4853",
+                                    "localId" : "5039",
                                     "name" : "{http://hl7.org/fhir}integer",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4854",
+                                    "localId" : "5040",
                                     "name" : "{http://hl7.org/fhir}markdown",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4855",
+                                    "localId" : "5041",
                                     "name" : "{http://hl7.org/fhir}oid",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4856",
+                                    "localId" : "5042",
                                     "name" : "{http://hl7.org/fhir}positiveInt",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4857",
+                                    "localId" : "5043",
                                     "name" : "{http://hl7.org/fhir}string",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4858",
+                                    "localId" : "5044",
                                     "name" : "{http://hl7.org/fhir}time",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4859",
+                                    "localId" : "5045",
                                     "name" : "{http://hl7.org/fhir}unsignedInt",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4860",
+                                    "localId" : "5046",
                                     "name" : "{http://hl7.org/fhir}uri",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4861",
+                                    "localId" : "5047",
                                     "name" : "{http://hl7.org/fhir}url",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4862",
+                                    "localId" : "5048",
                                     "name" : "{http://hl7.org/fhir}uuid",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4863",
+                                    "localId" : "5049",
                                     "name" : "{http://hl7.org/fhir}Address",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4864",
+                                    "localId" : "5050",
                                     "name" : "{http://hl7.org/fhir}Age",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4865",
+                                    "localId" : "5051",
                                     "name" : "{http://hl7.org/fhir}Annotation",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4866",
+                                    "localId" : "5052",
                                     "name" : "{http://hl7.org/fhir}Attachment",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4867",
+                                    "localId" : "5053",
                                     "name" : "{http://hl7.org/fhir}CodeableConcept",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4868",
+                                    "localId" : "5054",
                                     "name" : "{http://hl7.org/fhir}Coding",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4869",
+                                    "localId" : "5055",
                                     "name" : "{http://hl7.org/fhir}ContactPoint",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4870",
+                                    "localId" : "5056",
                                     "name" : "{http://hl7.org/fhir}Count",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4871",
+                                    "localId" : "5057",
                                     "name" : "{http://hl7.org/fhir}Distance",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4872",
+                                    "localId" : "5058",
                                     "name" : "{http://hl7.org/fhir}Duration",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4873",
+                                    "localId" : "5059",
                                     "name" : "{http://hl7.org/fhir}HumanName",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4874",
+                                    "localId" : "5060",
                                     "name" : "{http://hl7.org/fhir}Identifier",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4875",
+                                    "localId" : "5061",
                                     "name" : "{http://hl7.org/fhir}Money",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4876",
+                                    "localId" : "5062",
                                     "name" : "{http://hl7.org/fhir}Period",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4877",
+                                    "localId" : "5063",
                                     "name" : "{http://hl7.org/fhir}Quantity",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4878",
+                                    "localId" : "5064",
                                     "name" : "{http://hl7.org/fhir}Range",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4879",
+                                    "localId" : "5065",
                                     "name" : "{http://hl7.org/fhir}Ratio",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4880",
+                                    "localId" : "5066",
                                     "name" : "{http://hl7.org/fhir}Reference",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4881",
+                                    "localId" : "5067",
                                     "name" : "{http://hl7.org/fhir}SampledData",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4882",
+                                    "localId" : "5068",
                                     "name" : "{http://hl7.org/fhir}Signature",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4883",
+                                    "localId" : "5069",
                                     "name" : "{http://hl7.org/fhir}Timing",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4884",
+                                    "localId" : "5070",
                                     "name" : "{http://hl7.org/fhir}ContactDetail",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4885",
+                                    "localId" : "5071",
                                     "name" : "{http://hl7.org/fhir}Contributor",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4886",
+                                    "localId" : "5072",
                                     "name" : "{http://hl7.org/fhir}DataRequirement",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4887",
+                                    "localId" : "5073",
                                     "name" : "{http://hl7.org/fhir}Expression",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4888",
+                                    "localId" : "5074",
                                     "name" : "{http://hl7.org/fhir}ParameterDefinition",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4889",
+                                    "localId" : "5075",
                                     "name" : "{http://hl7.org/fhir}RelatedArtifact",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4890",
+                                    "localId" : "5076",
                                     "name" : "{http://hl7.org/fhir}TriggerDefinition",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4891",
+                                    "localId" : "5077",
                                     "name" : "{http://hl7.org/fhir}UsageContext",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4892",
+                                    "localId" : "5078",
                                     "name" : "{http://hl7.org/fhir}Dosage",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "4893",
+                                    "localId" : "5079",
                                     "name" : "{http://hl7.org/fhir}Meta",
                                     "type" : "NamedTypeSpecifier"
                                  } ]
                               }
                            },
                            "asTypeSpecifier" : {
-                              "localId" : "4894",
+                              "localId" : "5080",
                               "locator" : "335:24-335:35",
                               "resultTypeName" : "{http://hl7.org/fhir}boolean",
                               "name" : "{http://hl7.org/fhir}boolean",
@@ -5860,7 +5860,7 @@
                            }
                         } ]
                      }, {
-                        "localId" : "4895",
+                        "localId" : "5081",
                         "locator" : "335:39-335:42",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                         "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -6181,51 +6181,51 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4535",
+               "localId" : "4709",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4536",
+                  "localId" : "4710",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4537",
+                     "localId" : "4711",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4538",
+                        "localId" : "4712",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4539",
+                     "localId" : "4713",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4540",
+                        "localId" : "4714",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4541",
+                     "localId" : "4715",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4542",
+                        "localId" : "4716",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4543",
+                     "localId" : "4717",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4544",
+                        "localId" : "4718",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4545",
+                     "localId" : "4719",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4546",
+                        "localId" : "4720",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4547",
+                           "localId" : "4721",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -6815,38 +6815,38 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4548",
+               "localId" : "4722",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4549",
+                  "localId" : "4723",
                   "type" : "ChoiceTypeSpecifier",
                   "type" : [ ],
                   "choice" : [ {
-                     "localId" : "4550",
+                     "localId" : "4724",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4551",
+                        "localId" : "4725",
                         "name" : "familyMemberHistory",
                         "elementType" : {
-                           "localId" : "4552",
+                           "localId" : "4726",
                            "name" : "{http://hl7.org/fhir}FamilyMemberHistory",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4553",
+                        "localId" : "4727",
                         "name" : "conditions",
                         "elementType" : {
-                           "localId" : "4554",
+                           "localId" : "4728",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4555",
+                              "localId" : "4729",
                               "name" : "{http://hl7.org/fhir}FamilyMemberHistory.Condition",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      } ]
                   }, {
-                     "localId" : "4556",
+                     "localId" : "4730",
                      "name" : "{http://hl7.org/fhir}Condition",
                      "type" : "NamedTypeSpecifier"
                   } ]
@@ -7646,41 +7646,41 @@
                   "s" : [ {
                      "value" : [ "","define function Onset(c FHIR.FamilyMemberHistory.Condition):\n  " ]
                   }, {
-                     "r" : "5002",
+                     "r" : "5188",
                      "s" : [ {
-                        "r" : "5002",
+                        "r" : "5188",
                         "s" : [ {
                            "value" : [ "Coalesce","( " ]
                         }, {
-                           "r" : "4909",
+                           "r" : "5095",
                            "s" : [ {
                               "value" : [ "List{\n    " ]
                            }, {
-                              "r" : "4925",
+                              "r" : "5111",
                               "s" : [ {
-                                 "r" : "4910",
+                                 "r" : "5096",
                                  "s" : [ {
                                     "value" : [ "Common" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "4925",
+                                 "r" : "5111",
                                  "s" : [ {
                                     "value" : [ "QuantityText","(" ]
                                  }, {
-                                    "r" : "4911",
+                                    "r" : "5097",
                                     "s" : [ {
-                                       "r" : "4913",
+                                       "r" : "5099",
                                        "s" : [ {
-                                          "r" : "4912",
+                                          "r" : "5098",
                                           "s" : [ {
                                              "value" : [ "c" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "4913",
+                                          "r" : "5099",
                                           "s" : [ {
                                              "value" : [ "onset" ]
                                           } ]
@@ -7688,7 +7688,7 @@
                                     }, {
                                        "value" : [ " as " ]
                                     }, {
-                                       "r" : "4924",
+                                       "r" : "5110",
                                        "s" : [ {
                                           "value" : [ "FHIR",".","Age" ]
                                        } ]
@@ -7700,31 +7700,31 @@
                            }, {
                               "value" : [ ",\n    " ]
                            }, {
-                              "r" : "4942",
+                              "r" : "5128",
                               "s" : [ {
-                                 "r" : "4927",
+                                 "r" : "5113",
                                  "s" : [ {
                                     "value" : [ "Common" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "4942",
+                                 "r" : "5128",
                                  "s" : [ {
                                     "value" : [ "PeriodObject","(" ]
                                  }, {
-                                    "r" : "4928",
+                                    "r" : "5114",
                                     "s" : [ {
-                                       "r" : "4930",
+                                       "r" : "5116",
                                        "s" : [ {
-                                          "r" : "4929",
+                                          "r" : "5115",
                                           "s" : [ {
                                              "value" : [ "c" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "4930",
+                                          "r" : "5116",
                                           "s" : [ {
                                              "value" : [ "onset" ]
                                           } ]
@@ -7732,7 +7732,7 @@
                                     }, {
                                        "value" : [ " as " ]
                                     }, {
-                                       "r" : "4941",
+                                       "r" : "5127",
                                        "s" : [ {
                                           "value" : [ "FHIR",".","Period" ]
                                        } ]
@@ -7744,31 +7744,31 @@
                            }, {
                               "value" : [ ",\n    " ]
                            }, {
-                              "r" : "4969",
+                              "r" : "5155",
                               "s" : [ {
-                                 "r" : "4954",
+                                 "r" : "5140",
                                  "s" : [ {
                                     "value" : [ "Common" ]
                                  } ]
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "4969",
+                                 "r" : "5155",
                                  "s" : [ {
                                     "value" : [ "RangeObject","(" ]
                                  }, {
-                                    "r" : "4955",
+                                    "r" : "5141",
                                     "s" : [ {
-                                       "r" : "4957",
+                                       "r" : "5143",
                                        "s" : [ {
-                                          "r" : "4956",
+                                          "r" : "5142",
                                           "s" : [ {
                                              "value" : [ "c" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "4957",
+                                          "r" : "5143",
                                           "s" : [ {
                                              "value" : [ "onset" ]
                                           } ]
@@ -7776,7 +7776,7 @@
                                     }, {
                                        "value" : [ " as " ]
                                     }, {
-                                       "r" : "4968",
+                                       "r" : "5154",
                                        "s" : [ {
                                           "value" : [ "FHIR",".","Range" ]
                                        } ]
@@ -7788,24 +7788,24 @@
                            }, {
                               "value" : [ ",\n    " ]
                            }, {
-                              "r" : "4995",
+                              "r" : "5181",
                               "s" : [ {
-                                 "r" : "4981",
+                                 "r" : "5167",
                                  "s" : [ {
                                     "value" : [ "(" ]
                                  }, {
-                                    "r" : "4981",
+                                    "r" : "5167",
                                     "s" : [ {
-                                       "r" : "4983",
+                                       "r" : "5169",
                                        "s" : [ {
-                                          "r" : "4982",
+                                          "r" : "5168",
                                           "s" : [ {
                                              "value" : [ "c" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "4983",
+                                          "r" : "5169",
                                           "s" : [ {
                                              "value" : [ "onset" ]
                                           } ]
@@ -7813,7 +7813,7 @@
                                     }, {
                                        "value" : [ " as " ]
                                     }, {
-                                       "r" : "4994",
+                                       "r" : "5180",
                                        "s" : [ {
                                           "value" : [ "FHIR",".","string" ]
                                        } ]
@@ -7824,7 +7824,7 @@
                               }, {
                                  "value" : [ "." ]
                               }, {
-                                 "r" : "4995",
+                                 "r" : "5181",
                                  "s" : [ {
                                     "value" : [ "value" ]
                                  } ]
@@ -7840,80 +7840,80 @@
                }
             } ],
             "expression" : {
-               "localId" : "5002",
+               "localId" : "5188",
                "locator" : "338:3-343:4",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                "type" : "Coalesce",
                "signature" : [ {
-                  "localId" : "5003",
+                  "localId" : "5189",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "5004",
+                     "localId" : "5190",
                      "name" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "operand" : [ {
-                  "localId" : "4909",
+                  "localId" : "5095",
                   "locator" : "338:13-343:3",
                   "type" : "List",
                   "resultTypeSpecifier" : {
-                     "localId" : "4996",
+                     "localId" : "5182",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "4997",
+                        "localId" : "5183",
                         "name" : "{urn:hl7-org:elm-types:r1}Any",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "element" : [ {
-                     "localId" : "4925",
+                     "localId" : "5111",
                      "locator" : "339:5-339:44",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "name" : "QuantityText",
                      "libraryName" : "Common",
                      "type" : "FunctionRef",
                      "signature" : [ {
-                        "localId" : "4926",
+                        "localId" : "5112",
                         "name" : "{http://hl7.org/fhir}Quantity",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4911",
+                        "localId" : "5097",
                         "locator" : "339:25-339:43",
                         "resultTypeName" : "{http://hl7.org/fhir}Age",
                         "strict" : false,
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "4913",
+                           "localId" : "5099",
                            "locator" : "339:25-339:31",
                            "path" : "onset",
                            "type" : "Property",
                            "resultTypeSpecifier" : {
-                              "localId" : "4919",
+                              "localId" : "5105",
                               "type" : "ChoiceTypeSpecifier",
                               "type" : [ ],
                               "choice" : [ {
-                                 "localId" : "4920",
+                                 "localId" : "5106",
                                  "name" : "{http://hl7.org/fhir}Age",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4921",
+                                 "localId" : "5107",
                                  "name" : "{http://hl7.org/fhir}Range",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4922",
+                                 "localId" : "5108",
                                  "name" : "{http://hl7.org/fhir}Period",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4923",
+                                 "localId" : "5109",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ]
                            },
                            "source" : {
-                              "localId" : "4912",
+                              "localId" : "5098",
                               "locator" : "339:25",
                               "resultTypeName" : "{http://hl7.org/fhir}FamilyMemberHistory.Condition",
                               "name" : "c",
@@ -7921,7 +7921,7 @@
                            }
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "4924",
+                           "localId" : "5110",
                            "locator" : "339:36-339:43",
                            "resultTypeName" : "{http://hl7.org/fhir}Age",
                            "name" : "{http://hl7.org/fhir}Age",
@@ -7929,73 +7929,73 @@
                         }
                      } ]
                   }, {
-                     "localId" : "4942",
+                     "localId" : "5128",
                      "locator" : "340:5-340:47",
                      "name" : "PeriodObject",
                      "libraryName" : "Common",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "4949",
+                        "localId" : "5135",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4950",
+                           "localId" : "5136",
                            "name" : "Start",
                            "elementType" : {
-                              "localId" : "4951",
+                              "localId" : "5137",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4952",
+                           "localId" : "5138",
                            "name" : "End",
                            "elementType" : {
-                              "localId" : "4953",
+                              "localId" : "5139",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      },
                      "signature" : [ {
-                        "localId" : "4943",
+                        "localId" : "5129",
                         "name" : "{http://hl7.org/fhir}Period",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4928",
+                        "localId" : "5114",
                         "locator" : "340:25-340:46",
                         "resultTypeName" : "{http://hl7.org/fhir}Period",
                         "strict" : false,
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "4930",
+                           "localId" : "5116",
                            "locator" : "340:25-340:31",
                            "path" : "onset",
                            "type" : "Property",
                            "resultTypeSpecifier" : {
-                              "localId" : "4936",
+                              "localId" : "5122",
                               "type" : "ChoiceTypeSpecifier",
                               "type" : [ ],
                               "choice" : [ {
-                                 "localId" : "4937",
+                                 "localId" : "5123",
                                  "name" : "{http://hl7.org/fhir}Age",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4938",
+                                 "localId" : "5124",
                                  "name" : "{http://hl7.org/fhir}Range",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4939",
+                                 "localId" : "5125",
                                  "name" : "{http://hl7.org/fhir}Period",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4940",
+                                 "localId" : "5126",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ]
                            },
                            "source" : {
-                              "localId" : "4929",
+                              "localId" : "5115",
                               "locator" : "340:25",
                               "resultTypeName" : "{http://hl7.org/fhir}FamilyMemberHistory.Condition",
                               "name" : "c",
@@ -8003,7 +8003,7 @@
                            }
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "4941",
+                           "localId" : "5127",
                            "locator" : "340:36-340:46",
                            "resultTypeName" : "{http://hl7.org/fhir}Period",
                            "name" : "{http://hl7.org/fhir}Period",
@@ -8011,73 +8011,73 @@
                         }
                      } ]
                   }, {
-                     "localId" : "4969",
+                     "localId" : "5155",
                      "locator" : "341:5-341:45",
                      "name" : "RangeObject",
                      "libraryName" : "Common",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "4976",
+                        "localId" : "5162",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4977",
+                           "localId" : "5163",
                            "name" : "Low",
                            "elementType" : {
-                              "localId" : "4978",
+                              "localId" : "5164",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4979",
+                           "localId" : "5165",
                            "name" : "High",
                            "elementType" : {
-                              "localId" : "4980",
+                              "localId" : "5166",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      },
                      "signature" : [ {
-                        "localId" : "4970",
+                        "localId" : "5156",
                         "name" : "{http://hl7.org/fhir}Range",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "4955",
+                        "localId" : "5141",
                         "locator" : "341:24-341:44",
                         "resultTypeName" : "{http://hl7.org/fhir}Range",
                         "strict" : false,
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "4957",
+                           "localId" : "5143",
                            "locator" : "341:24-341:30",
                            "path" : "onset",
                            "type" : "Property",
                            "resultTypeSpecifier" : {
-                              "localId" : "4963",
+                              "localId" : "5149",
                               "type" : "ChoiceTypeSpecifier",
                               "type" : [ ],
                               "choice" : [ {
-                                 "localId" : "4964",
+                                 "localId" : "5150",
                                  "name" : "{http://hl7.org/fhir}Age",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4965",
+                                 "localId" : "5151",
                                  "name" : "{http://hl7.org/fhir}Range",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4966",
+                                 "localId" : "5152",
                                  "name" : "{http://hl7.org/fhir}Period",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4967",
+                                 "localId" : "5153",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ]
                            },
                            "source" : {
-                              "localId" : "4956",
+                              "localId" : "5142",
                               "locator" : "341:24",
                               "resultTypeName" : "{http://hl7.org/fhir}FamilyMemberHistory.Condition",
                               "name" : "c",
@@ -8085,7 +8085,7 @@
                            }
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "4968",
+                           "localId" : "5154",
                            "locator" : "341:35-341:44",
                            "resultTypeName" : "{http://hl7.org/fhir}Range",
                            "name" : "{http://hl7.org/fhir}Range",
@@ -8093,47 +8093,47 @@
                         }
                      } ]
                   }, {
-                     "localId" : "4995",
+                     "localId" : "5181",
                      "locator" : "342:5-342:34",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "path" : "value",
                      "type" : "Property",
                      "source" : {
-                        "localId" : "4981",
+                        "localId" : "5167",
                         "locator" : "342:5-342:28",
                         "resultTypeName" : "{http://hl7.org/fhir}string",
                         "strict" : false,
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "4983",
+                           "localId" : "5169",
                            "locator" : "342:6-342:12",
                            "path" : "onset",
                            "type" : "Property",
                            "resultTypeSpecifier" : {
-                              "localId" : "4989",
+                              "localId" : "5175",
                               "type" : "ChoiceTypeSpecifier",
                               "type" : [ ],
                               "choice" : [ {
-                                 "localId" : "4990",
+                                 "localId" : "5176",
                                  "name" : "{http://hl7.org/fhir}Age",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4991",
+                                 "localId" : "5177",
                                  "name" : "{http://hl7.org/fhir}Range",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4992",
+                                 "localId" : "5178",
                                  "name" : "{http://hl7.org/fhir}Period",
                                  "type" : "NamedTypeSpecifier"
                               }, {
-                                 "localId" : "4993",
+                                 "localId" : "5179",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ]
                            },
                            "source" : {
-                              "localId" : "4982",
+                              "localId" : "5168",
                               "locator" : "342:6",
                               "resultTypeName" : "{http://hl7.org/fhir}FamilyMemberHistory.Condition",
                               "name" : "c",
@@ -8141,7 +8141,7 @@
                            }
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "4994",
+                           "localId" : "5180",
                            "locator" : "342:17-342:27",
                            "resultTypeName" : "{http://hl7.org/fhir}string",
                            "name" : "{http://hl7.org/fhir}string",
@@ -8409,54 +8409,54 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4557",
+               "localId" : "4731",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4558",
+                  "localId" : "4732",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4559",
+                     "localId" : "4733",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4560",
+                        "localId" : "4734",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "4561",
+                           "localId" : "4735",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4562",
+                        "localId" : "4736",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "4563",
+                           "localId" : "4737",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4564",
+                        "localId" : "4738",
                         "name" : "onset",
                         "elementType" : {
-                           "localId" : "4565",
+                           "localId" : "4739",
                            "name" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4566",
+                        "localId" : "4740",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "4567",
+                           "localId" : "4741",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4568",
+                        "localId" : "4742",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "4569",
+                           "localId" : "4743",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4570",
+                              "localId" : "4744",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -9094,10 +9094,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4571",
+               "localId" : "4745",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4572",
+                  "localId" : "4746",
                   "name" : "{http://hl7.org/fhir}Observation",
                   "type" : "NamedTypeSpecifier"
                }
@@ -9476,51 +9476,51 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4573",
+               "localId" : "4747",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4574",
+                  "localId" : "4748",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4575",
+                     "localId" : "4749",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4576",
+                        "localId" : "4750",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4577",
+                     "localId" : "4751",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4578",
+                        "localId" : "4752",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4579",
+                     "localId" : "4753",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4580",
+                        "localId" : "4754",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4581",
+                     "localId" : "4755",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4582",
+                        "localId" : "4756",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4583",
+                     "localId" : "4757",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4584",
+                        "localId" : "4758",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4585",
+                           "localId" : "4759",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -9980,10 +9980,10 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4586",
+               "localId" : "4760",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4587",
+                  "localId" : "4761",
                   "name" : "{http://hl7.org/fhir}Procedure",
                   "type" : "NamedTypeSpecifier"
                }
@@ -10217,51 +10217,51 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4588",
+               "localId" : "4762",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4589",
+                  "localId" : "4763",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4590",
+                     "localId" : "4764",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4591",
+                        "localId" : "4765",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4592",
+                     "localId" : "4766",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4593",
+                        "localId" : "4767",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4594",
+                     "localId" : "4768",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4595",
+                        "localId" : "4769",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4596",
+                     "localId" : "4770",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4597",
+                        "localId" : "4771",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4598",
+                     "localId" : "4772",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4599",
+                        "localId" : "4773",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4600",
+                           "localId" : "4774",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -10610,7 +10610,7 @@
             }
          }, {
             "localId" : "2461",
-            "locator" : "345:1-355:3",
+            "locator" : "345:1-364:3",
             "name" : "FormatReports",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -10622,18 +10622,18 @@
                   "s" : [ {
                      "value" : [ "","define function FormatReports(DrList List<DiagnosticReport>, ObsList List<Observation>, ReportType String):\n  " ]
                   }, {
-                     "r" : "5089",
+                     "r" : "5371",
                      "s" : [ {
-                        "r" : "5089",
+                        "r" : "5371",
                         "s" : [ {
                            "s" : [ {
-                              "r" : "5005",
+                              "r" : "5191",
                               "s" : [ {
-                                 "r" : "5006",
+                                 "r" : "5192",
                                  "s" : [ {
                                     "value" : [ "(" ]
                                  }, {
-                                    "r" : "5006",
+                                    "r" : "5192",
                                     "s" : [ {
                                        "value" : [ "DrList" ]
                                     } ]
@@ -10650,31 +10650,31 @@
                            "s" : [ {
                               "value" : [ "let " ]
                            }, {
-                              "r" : "5013",
+                              "r" : "5199",
                               "s" : [ {
                                  "value" : [ "CollatedCodes",": " ]
                               }, {
-                                 "r" : "5019",
+                                 "r" : "5205",
                                  "s" : [ {
-                                    "r" : "5014",
+                                    "r" : "5200",
                                     "s" : [ {
                                        "value" : [ "CRCSMCommon" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "5019",
+                                    "r" : "5205",
                                     "s" : [ {
                                        "value" : [ "CollateConclusionCodes","(" ]
                                     }, {
-                                       "r" : "5015",
+                                       "r" : "5201",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
                                     }, {
                                        "value" : [ "," ]
                                     }, {
-                                       "r" : "5016",
+                                       "r" : "5202",
                                        "s" : [ {
                                           "value" : [ "ObsList" ]
                                        } ]
@@ -10687,18 +10687,18 @@
                         }, {
                            "value" : [ "\n  " ]
                         }, {
-                           "r" : "5029",
+                           "r" : "5215",
                            "s" : [ {
                               "value" : [ "return " ]
                            }, {
-                              "r" : "5030",
+                              "r" : "5216",
                               "s" : [ {
                                  "value" : [ "{\n    " ]
                               }, {
                                  "s" : [ {
                                     "value" : [ "name",": " ]
                                  }, {
-                                    "r" : "5031",
+                                    "r" : "5217",
                                     "s" : [ {
                                        "value" : [ "ReportType" ]
                                     } ]
@@ -10709,29 +10709,29 @@
                                  "s" : [ {
                                     "value" : [ "longName",": " ]
                                  }, {
-                                    "r" : "5035",
+                                    "r" : "5221",
                                     "s" : [ {
-                                       "r" : "5032",
+                                       "r" : "5218",
                                        "s" : [ {
                                           "value" : [ "Common" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "5035",
+                                       "r" : "5221",
                                        "s" : [ {
                                           "value" : [ "ConceptText","(" ]
                                        }, {
-                                          "r" : "5034",
+                                          "r" : "5220",
                                           "s" : [ {
-                                             "r" : "5033",
+                                             "r" : "5219",
                                              "s" : [ {
                                                 "value" : [ "D" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "5034",
+                                             "r" : "5220",
                                              "s" : [ {
                                                 "value" : [ "code" ]
                                              } ]
@@ -10747,31 +10747,229 @@
                                  "s" : [ {
                                     "value" : [ "value",": " ]
                                  }, {
-                                    "r" : "5037",
+                                    "r" : "5271",
                                     "s" : [ {
-                                       "value" : [ "CollatedCodes" ]
+                                       "value" : [ "First","(" ]
+                                    }, {
+                                       "r" : "5223",
+                                       "s" : [ {
+                                          "value" : [ "flatten" ]
+                                       }, {
+                                          "r" : "5255",
+                                          "s" : [ {
+                                             "value" : [ "(\n      " ]
+                                          }, {
+                                             "r" : "5255",
+                                             "s" : [ {
+                                                "s" : [ {
+                                                   "r" : "5224",
+                                                   "s" : [ {
+                                                      "r" : "5225",
+                                                      "s" : [ {
+                                                         "value" : [ "(" ]
+                                                      }, {
+                                                         "r" : "5225",
+                                                         "s" : [ {
+                                                            "value" : [ "CollatedCodes" ]
+                                                         } ]
+                                                      }, {
+                                                         "value" : [ ")" ]
+                                                      } ]
+                                                   }, {
+                                                      "value" : [ " ","cC" ]
+                                                   } ]
+                                                } ]
+                                             }, {
+                                                "value" : [ "\n        " ]
+                                             }, {
+                                                "r" : "5232",
+                                                "s" : [ {
+                                                   "value" : [ "return " ]
+                                                }, {
+                                                   "r" : "5249",
+                                                   "s" : [ {
+                                                      "s" : [ {
+                                                         "r" : "5233",
+                                                         "s" : [ {
+                                                            "r" : "5235",
+                                                            "s" : [ {
+                                                               "value" : [ "(" ]
+                                                            }, {
+                                                               "r" : "5235",
+                                                               "s" : [ {
+                                                                  "r" : "5234",
+                                                                  "s" : [ {
+                                                                     "value" : [ "cC" ]
+                                                                  } ]
+                                                               }, {
+                                                                  "value" : [ "." ]
+                                                               }, {
+                                                                  "r" : "5235",
+                                                                  "s" : [ {
+                                                                     "value" : [ "coding" ]
+                                                                  } ]
+                                                               } ]
+                                                            }, {
+                                                               "value" : [ ")" ]
+                                                            } ]
+                                                         }, {
+                                                            "value" : [ " ","cCC" ]
+                                                         } ]
+                                                      } ]
+                                                   }, {
+                                                      "value" : [ "\n          " ]
+                                                   }, {
+                                                      "r" : "5244",
+                                                      "s" : [ {
+                                                         "value" : [ "return " ]
+                                                      }, {
+                                                         "r" : "5246",
+                                                         "s" : [ {
+                                                            "r" : "5245",
+                                                            "s" : [ {
+                                                               "value" : [ "cCC" ]
+                                                            } ]
+                                                         }, {
+                                                            "value" : [ "." ]
+                                                         }, {
+                                                            "r" : "5246",
+                                                            "s" : [ {
+                                                               "value" : [ "display" ]
+                                                            } ]
+                                                         } ]
+                                                      } ]
+                                                   } ]
+                                                } ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "\n    )" ]
+                                          } ]
+                                       } ]
+                                    }, {
+                                       "value" : [ ")" ]
                                     } ]
                                  } ]
                               }, {
-                                 "value" : [ ", //TODO: what to return for report value??\n    " ]
+                                 "value" : [ ",\n    " ]
+                              }, {
+                                 "s" : [ {
+                                    "value" : [ "longValue",": " ]
+                                 }, {
+                                    "r" : "5274",
+                                    "s" : [ {
+                                       "value" : [ "flatten" ]
+                                    }, {
+                                       "r" : "5306",
+                                       "s" : [ {
+                                          "value" : [ "(\n      " ]
+                                       }, {
+                                          "r" : "5306",
+                                          "s" : [ {
+                                             "s" : [ {
+                                                "r" : "5275",
+                                                "s" : [ {
+                                                   "r" : "5276",
+                                                   "s" : [ {
+                                                      "value" : [ "(" ]
+                                                   }, {
+                                                      "r" : "5276",
+                                                      "s" : [ {
+                                                         "value" : [ "CollatedCodes" ]
+                                                      } ]
+                                                   }, {
+                                                      "value" : [ ")" ]
+                                                   } ]
+                                                }, {
+                                                   "value" : [ " ","cC" ]
+                                                } ]
+                                             } ]
+                                          }, {
+                                             "value" : [ "\n        " ]
+                                          }, {
+                                             "r" : "5283",
+                                             "s" : [ {
+                                                "value" : [ "return " ]
+                                             }, {
+                                                "r" : "5300",
+                                                "s" : [ {
+                                                   "s" : [ {
+                                                      "r" : "5284",
+                                                      "s" : [ {
+                                                         "r" : "5286",
+                                                         "s" : [ {
+                                                            "value" : [ "(" ]
+                                                         }, {
+                                                            "r" : "5286",
+                                                            "s" : [ {
+                                                               "r" : "5285",
+                                                               "s" : [ {
+                                                                  "value" : [ "cC" ]
+                                                               } ]
+                                                            }, {
+                                                               "value" : [ "." ]
+                                                            }, {
+                                                               "r" : "5286",
+                                                               "s" : [ {
+                                                                  "value" : [ "coding" ]
+                                                               } ]
+                                                            } ]
+                                                         }, {
+                                                            "value" : [ ")" ]
+                                                         } ]
+                                                      }, {
+                                                         "value" : [ " ","cCC" ]
+                                                      } ]
+                                                   } ]
+                                                }, {
+                                                   "value" : [ "\n          " ]
+                                                }, {
+                                                   "r" : "5295",
+                                                   "s" : [ {
+                                                      "value" : [ "return " ]
+                                                   }, {
+                                                      "r" : "5297",
+                                                      "s" : [ {
+                                                         "r" : "5296",
+                                                         "s" : [ {
+                                                            "value" : [ "cCC" ]
+                                                         } ]
+                                                      }, {
+                                                         "value" : [ "." ]
+                                                      }, {
+                                                         "r" : "5297",
+                                                         "s" : [ {
+                                                            "value" : [ "display" ]
+                                                         } ]
+                                                      } ]
+                                                   } ]
+                                                } ]
+                                             } ]
+                                          } ]
+                                       }, {
+                                          "value" : [ "\n    )" ]
+                                       } ]
+                                    } ]
+                                 } ]
+                              }, {
+                                 "value" : [ ",\n    " ]
                               }, {
                                  "s" : [ {
                                     "value" : [ "date",": " ]
                                  }, {
-                                    "r" : "5042",
+                                    "r" : "5320",
                                     "s" : [ {
-                                       "r" : "5040",
+                                       "r" : "5318",
                                        "s" : [ {
                                           "value" : [ "Common" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "5042",
+                                       "r" : "5320",
                                        "s" : [ {
                                           "value" : [ "DiagnosticReportDateString","(" ]
                                        }, {
-                                          "r" : "5041",
+                                          "r" : "5319",
                                           "s" : [ {
                                              "value" : [ "D" ]
                                           } ]
@@ -10786,25 +10984,25 @@
                                  "s" : [ {
                                     "value" : [ "reference",": " ]
                                  }, {
-                                    "r" : "5052",
+                                    "r" : "5330",
                                     "s" : [ {
-                                       "r" : "5045",
+                                       "r" : "5323",
                                        "s" : [ {
                                           "value" : [ "'DiagnosticReport/'" ]
                                        } ]
                                     }, {
                                        "value" : [ " + " ]
                                     }, {
-                                       "r" : "5047",
+                                       "r" : "5325",
                                        "s" : [ {
-                                          "r" : "5046",
+                                          "r" : "5324",
                                           "s" : [ {
                                              "value" : [ "D" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "5047",
+                                          "r" : "5325",
                                           "s" : [ {
                                              "value" : [ "id" ]
                                           } ]
@@ -10817,11 +11015,11 @@
                                  "s" : [ {
                                     "value" : [ "edited",": " ]
                                  }, {
-                                    "r" : "5054",
+                                    "r" : "5332",
                                     "s" : [ {
                                        "value" : [ "HasBeenLocallyEdited","(" ]
                                     }, {
-                                       "r" : "5053",
+                                       "r" : "5331",
                                        "s" : [ {
                                           "value" : [ "D" ]
                                        } ]
@@ -10839,63 +11037,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "5122",
+               "localId" : "5408",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "5123",
+                  "localId" : "5409",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "5124",
+                     "localId" : "5410",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "5125",
+                        "localId" : "5411",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "5126",
+                     "localId" : "5412",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "5127",
+                        "localId" : "5413",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "5128",
+                     "localId" : "5414",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "5129",
+                        "localId" : "5415",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "5416",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "5417",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "5130",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "5418",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "5131",
+                     "localId" : "5419",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "5132",
+                        "localId" : "5420",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "5133",
+                     "localId" : "5421",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "5134",
+                        "localId" : "5422",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "5135",
+                     "localId" : "5423",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "5136",
+                        "localId" : "5424",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "5137",
+                           "localId" : "5425",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -10904,67 +11110,75 @@
                }
             },
             "expression" : {
-               "localId" : "5089",
-               "locator" : "346:3-355:3",
+               "localId" : "5371",
+               "locator" : "346:3-364:3",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "5106",
+                  "localId" : "5390",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "5107",
+                     "localId" : "5391",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "5108",
+                        "localId" : "5392",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "5109",
+                           "localId" : "5393",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "5110",
+                        "localId" : "5394",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "5111",
+                           "localId" : "5395",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "5112",
+                        "localId" : "5396",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "5113",
+                           "localId" : "5397",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "5398",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "5399",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "5114",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "5400",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "5115",
+                        "localId" : "5401",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "5116",
+                           "localId" : "5402",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "5117",
+                        "localId" : "5403",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "5118",
+                           "localId" : "5404",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "5119",
+                        "localId" : "5405",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "5120",
+                           "localId" : "5406",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "5121",
+                              "localId" : "5407",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -10973,28 +11187,28 @@
                   }
                },
                "source" : [ {
-                  "localId" : "5005",
+                  "localId" : "5191",
                   "locator" : "346:3-346:12",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "5011",
+                     "localId" : "5197",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "5012",
+                        "localId" : "5198",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "5006",
+                     "localId" : "5192",
                      "locator" : "346:3-346:10",
                      "name" : "DrList",
                      "type" : "OperandRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "5009",
+                        "localId" : "5195",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "5010",
+                           "localId" : "5196",
                            "name" : "{http://hl7.org/fhir}DiagnosticReport",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -11002,62 +11216,62 @@
                   }
                } ],
                "let" : [ {
-                  "localId" : "5013",
+                  "localId" : "5199",
                   "locator" : "347:7-347:66",
                   "identifier" : "CollatedCodes",
                   "resultTypeSpecifier" : {
-                     "localId" : "5027",
+                     "localId" : "5213",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "5028",
+                        "localId" : "5214",
                         "name" : "{http://hl7.org/fhir}CodeableConcept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "5019",
+                     "localId" : "5205",
                      "locator" : "347:22-347:66",
                      "name" : "CollateConclusionCodes",
                      "libraryName" : "CRCSMCommon",
                      "type" : "FunctionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "5025",
+                        "localId" : "5211",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "5026",
+                           "localId" : "5212",
                            "name" : "{http://hl7.org/fhir}CodeableConcept",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "signature" : [ {
-                        "localId" : "5020",
+                        "localId" : "5206",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "5021",
+                        "localId" : "5207",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "5022",
+                           "localId" : "5208",
                            "name" : "{http://hl7.org/fhir}Observation",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "5015",
+                        "localId" : "5201",
                         "locator" : "347:57",
                         "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                         "name" : "D",
                         "type" : "AliasRef"
                      }, {
-                        "localId" : "5016",
+                        "localId" : "5202",
                         "locator" : "347:59-347:65",
                         "name" : "ObsList",
                         "type" : "OperandRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "5017",
+                           "localId" : "5203",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "5018",
+                              "localId" : "5204",
                               "name" : "{http://hl7.org/fhir}Observation",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -11067,66 +11281,74 @@
                } ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "5029",
-                  "locator" : "348:3-355:3",
+                  "localId" : "5215",
+                  "locator" : "348:3-364:3",
                   "resultTypeSpecifier" : {
-                     "localId" : "5073",
+                     "localId" : "5353",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "5074",
+                        "localId" : "5354",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "5075",
+                           "localId" : "5355",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "5076",
+                              "localId" : "5356",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5077",
+                           "localId" : "5357",
                            "name" : "longName",
                            "elementType" : {
-                              "localId" : "5078",
+                              "localId" : "5358",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5079",
+                           "localId" : "5359",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "5080",
+                              "localId" : "5360",
+                              "name" : "{http://hl7.org/fhir}string",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }, {
+                           "localId" : "5361",
+                           "name" : "longValue",
+                           "elementType" : {
+                              "localId" : "5362",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5081",
-                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "localId" : "5363",
+                                 "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }
                         }, {
-                           "localId" : "5082",
+                           "localId" : "5364",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "5083",
+                              "localId" : "5365",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5084",
+                           "localId" : "5366",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "5085",
+                              "localId" : "5367",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5086",
+                           "localId" : "5368",
                            "name" : "edited",
                            "elementType" : {
-                              "localId" : "5087",
+                              "localId" : "5369",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5088",
+                                 "localId" : "5370",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -11135,64 +11357,72 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "5030",
-                     "locator" : "348:10-355:3",
+                     "localId" : "5216",
+                     "locator" : "348:10-364:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "5058",
+                        "localId" : "5336",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "5059",
+                           "localId" : "5337",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "5060",
+                              "localId" : "5338",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5061",
+                           "localId" : "5339",
                            "name" : "longName",
                            "elementType" : {
-                              "localId" : "5062",
+                              "localId" : "5340",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5063",
+                           "localId" : "5341",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "5064",
+                              "localId" : "5342",
+                              "name" : "{http://hl7.org/fhir}string",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }, {
+                           "localId" : "5343",
+                           "name" : "longValue",
+                           "elementType" : {
+                              "localId" : "5344",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5065",
-                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "localId" : "5345",
+                                 "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }
                         }, {
-                           "localId" : "5066",
+                           "localId" : "5346",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "5067",
+                              "localId" : "5347",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5068",
+                           "localId" : "5348",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "5069",
+                              "localId" : "5349",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "5070",
+                           "localId" : "5350",
                            "name" : "edited",
                            "elementType" : {
-                              "localId" : "5071",
+                              "localId" : "5351",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5072",
+                                 "localId" : "5352",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -11202,7 +11432,7 @@
                      "element" : [ {
                         "name" : "name",
                         "value" : {
-                           "localId" : "5031",
+                           "localId" : "5217",
                            "locator" : "349:11-349:20",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ReportType",
@@ -11211,19 +11441,19 @@
                      }, {
                         "name" : "longName",
                         "value" : {
-                           "localId" : "5035",
+                           "localId" : "5221",
                            "locator" : "350:15-350:40",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ConceptText",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "5036",
+                              "localId" : "5222",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "5034",
+                              "localId" : "5220",
                               "locator" : "350:34-350:39",
                               "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                               "path" : "code",
@@ -11234,37 +11464,359 @@
                      }, {
                         "name" : "value",
                         "value" : {
-                           "localId" : "5037",
-                           "locator" : "351:12-351:24",
-                           "name" : "CollatedCodes",
-                           "type" : "QueryLetRef",
-                           "resultTypeSpecifier" : {
-                              "localId" : "5038",
+                           "localId" : "5271",
+                           "locator" : "351:12-355:6",
+                           "resultTypeName" : "{http://hl7.org/fhir}string",
+                           "type" : "First",
+                           "signature" : [ {
+                              "localId" : "5272",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5039",
-                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "localId" : "5273",
+                                 "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
+                              }
+                           } ],
+                           "source" : {
+                              "localId" : "5223",
+                              "locator" : "351:18-355:5",
+                              "type" : "Flatten",
+                              "resultTypeSpecifier" : {
+                                 "localId" : "5265",
+                                 "type" : "ListTypeSpecifier",
+                                 "elementType" : {
+                                    "localId" : "5266",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              },
+                              "signature" : [ {
+                                 "localId" : "5262",
+                                 "type" : "ListTypeSpecifier",
+                                 "elementType" : {
+                                    "localId" : "5263",
+                                    "type" : "ListTypeSpecifier",
+                                    "elementType" : {
+                                       "localId" : "5264",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              } ],
+                              "operand" : {
+                                 "localId" : "5255",
+                                 "locator" : "351:25-355:5",
+                                 "type" : "Query",
+                                 "resultTypeSpecifier" : {
+                                    "localId" : "5259",
+                                    "type" : "ListTypeSpecifier",
+                                    "elementType" : {
+                                       "localId" : "5260",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5261",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }
+                                 },
+                                 "source" : [ {
+                                    "localId" : "5224",
+                                    "locator" : "352:7-352:24",
+                                    "alias" : "cC",
+                                    "resultTypeSpecifier" : {
+                                       "localId" : "5230",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5231",
+                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    },
+                                    "expression" : {
+                                       "localId" : "5225",
+                                       "locator" : "352:7-352:21",
+                                       "name" : "CollatedCodes",
+                                       "type" : "QueryLetRef",
+                                       "resultTypeSpecifier" : {
+                                          "localId" : "5228",
+                                          "type" : "ListTypeSpecifier",
+                                          "elementType" : {
+                                             "localId" : "5229",
+                                             "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                             "type" : "NamedTypeSpecifier"
+                                          }
+                                       }
+                                    }
+                                 } ],
+                                 "let" : [ ],
+                                 "relationship" : [ ],
+                                 "return" : {
+                                    "localId" : "5232",
+                                    "locator" : "353:9-354:28",
+                                    "resultTypeSpecifier" : {
+                                       "localId" : "5252",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5253",
+                                          "type" : "ListTypeSpecifier",
+                                          "elementType" : {
+                                             "localId" : "5254",
+                                             "name" : "{http://hl7.org/fhir}string",
+                                             "type" : "NamedTypeSpecifier"
+                                          }
+                                       }
+                                    },
+                                    "expression" : {
+                                       "localId" : "5249",
+                                       "locator" : "353:16-354:28",
+                                       "type" : "Query",
+                                       "resultTypeSpecifier" : {
+                                          "localId" : "5250",
+                                          "type" : "ListTypeSpecifier",
+                                          "elementType" : {
+                                             "localId" : "5251",
+                                             "name" : "{http://hl7.org/fhir}string",
+                                             "type" : "NamedTypeSpecifier"
+                                          }
+                                       },
+                                       "source" : [ {
+                                          "localId" : "5233",
+                                          "locator" : "353:16-353:30",
+                                          "alias" : "cCC",
+                                          "resultTypeSpecifier" : {
+                                             "localId" : "5242",
+                                             "type" : "ListTypeSpecifier",
+                                             "elementType" : {
+                                                "localId" : "5243",
+                                                "name" : "{http://hl7.org/fhir}Coding",
+                                                "type" : "NamedTypeSpecifier"
+                                             }
+                                          },
+                                          "expression" : {
+                                             "localId" : "5235",
+                                             "locator" : "353:16-353:26",
+                                             "path" : "coding",
+                                             "scope" : "cC",
+                                             "type" : "Property",
+                                             "resultTypeSpecifier" : {
+                                                "localId" : "5240",
+                                                "type" : "ListTypeSpecifier",
+                                                "elementType" : {
+                                                   "localId" : "5241",
+                                                   "name" : "{http://hl7.org/fhir}Coding",
+                                                   "type" : "NamedTypeSpecifier"
+                                                }
+                                             }
+                                          }
+                                       } ],
+                                       "let" : [ ],
+                                       "relationship" : [ ],
+                                       "return" : {
+                                          "localId" : "5244",
+                                          "locator" : "354:11-354:28",
+                                          "resultTypeSpecifier" : {
+                                             "localId" : "5247",
+                                             "type" : "ListTypeSpecifier",
+                                             "elementType" : {
+                                                "localId" : "5248",
+                                                "name" : "{http://hl7.org/fhir}string",
+                                                "type" : "NamedTypeSpecifier"
+                                             }
+                                          },
+                                          "expression" : {
+                                             "localId" : "5246",
+                                             "locator" : "354:18-354:28",
+                                             "resultTypeName" : "{http://hl7.org/fhir}string",
+                                             "path" : "display",
+                                             "scope" : "cCC",
+                                             "type" : "Property"
+                                          }
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "longValue",
+                        "value" : {
+                           "localId" : "5274",
+                           "locator" : "356:16-360:5",
+                           "type" : "Flatten",
+                           "resultTypeSpecifier" : {
+                              "localId" : "5316",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "5317",
+                                 "name" : "{http://hl7.org/fhir}string",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           },
+                           "signature" : [ {
+                              "localId" : "5313",
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "localId" : "5314",
+                                 "type" : "ListTypeSpecifier",
+                                 "elementType" : {
+                                    "localId" : "5315",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }
+                           } ],
+                           "operand" : {
+                              "localId" : "5306",
+                              "locator" : "356:23-360:5",
+                              "type" : "Query",
+                              "resultTypeSpecifier" : {
+                                 "localId" : "5310",
+                                 "type" : "ListTypeSpecifier",
+                                 "elementType" : {
+                                    "localId" : "5311",
+                                    "type" : "ListTypeSpecifier",
+                                    "elementType" : {
+                                       "localId" : "5312",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "source" : [ {
+                                 "localId" : "5275",
+                                 "locator" : "357:7-357:24",
+                                 "alias" : "cC",
+                                 "resultTypeSpecifier" : {
+                                    "localId" : "5281",
+                                    "type" : "ListTypeSpecifier",
+                                    "elementType" : {
+                                       "localId" : "5282",
+                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 },
+                                 "expression" : {
+                                    "localId" : "5276",
+                                    "locator" : "357:7-357:21",
+                                    "name" : "CollatedCodes",
+                                    "type" : "QueryLetRef",
+                                    "resultTypeSpecifier" : {
+                                       "localId" : "5279",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5280",
+                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }
+                                 }
+                              } ],
+                              "let" : [ ],
+                              "relationship" : [ ],
+                              "return" : {
+                                 "localId" : "5283",
+                                 "locator" : "358:9-359:28",
+                                 "resultTypeSpecifier" : {
+                                    "localId" : "5303",
+                                    "type" : "ListTypeSpecifier",
+                                    "elementType" : {
+                                       "localId" : "5304",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5305",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }
+                                 },
+                                 "expression" : {
+                                    "localId" : "5300",
+                                    "locator" : "358:16-359:28",
+                                    "type" : "Query",
+                                    "resultTypeSpecifier" : {
+                                       "localId" : "5301",
+                                       "type" : "ListTypeSpecifier",
+                                       "elementType" : {
+                                          "localId" : "5302",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    },
+                                    "source" : [ {
+                                       "localId" : "5284",
+                                       "locator" : "358:16-358:30",
+                                       "alias" : "cCC",
+                                       "resultTypeSpecifier" : {
+                                          "localId" : "5293",
+                                          "type" : "ListTypeSpecifier",
+                                          "elementType" : {
+                                             "localId" : "5294",
+                                             "name" : "{http://hl7.org/fhir}Coding",
+                                             "type" : "NamedTypeSpecifier"
+                                          }
+                                       },
+                                       "expression" : {
+                                          "localId" : "5286",
+                                          "locator" : "358:16-358:26",
+                                          "path" : "coding",
+                                          "scope" : "cC",
+                                          "type" : "Property",
+                                          "resultTypeSpecifier" : {
+                                             "localId" : "5291",
+                                             "type" : "ListTypeSpecifier",
+                                             "elementType" : {
+                                                "localId" : "5292",
+                                                "name" : "{http://hl7.org/fhir}Coding",
+                                                "type" : "NamedTypeSpecifier"
+                                             }
+                                          }
+                                       }
+                                    } ],
+                                    "let" : [ ],
+                                    "relationship" : [ ],
+                                    "return" : {
+                                       "localId" : "5295",
+                                       "locator" : "359:11-359:28",
+                                       "resultTypeSpecifier" : {
+                                          "localId" : "5298",
+                                          "type" : "ListTypeSpecifier",
+                                          "elementType" : {
+                                             "localId" : "5299",
+                                             "name" : "{http://hl7.org/fhir}string",
+                                             "type" : "NamedTypeSpecifier"
+                                          }
+                                       },
+                                       "expression" : {
+                                          "localId" : "5297",
+                                          "locator" : "359:18-359:28",
+                                          "resultTypeName" : "{http://hl7.org/fhir}string",
+                                          "path" : "display",
+                                          "scope" : "cCC",
+                                          "type" : "Property"
+                                       }
+                                    }
+                                 }
                               }
                            }
                         }
                      }, {
                         "name" : "date",
                         "value" : {
-                           "localId" : "5042",
-                           "locator" : "352:11-352:46",
+                           "localId" : "5320",
+                           "locator" : "361:11-361:46",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "DiagnosticReportDateString",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "5043",
+                              "localId" : "5321",
                               "name" : "{http://hl7.org/fhir}DiagnosticReport",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "5041",
-                              "locator" : "352:45",
+                              "localId" : "5319",
+                              "locator" : "361:45",
                               "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                               "name" : "D",
                               "type" : "AliasRef"
@@ -11273,31 +11825,31 @@
                      }, {
                         "name" : "reference",
                         "value" : {
-                           "localId" : "5052",
-                           "locator" : "353:16-353:41",
+                           "localId" : "5330",
+                           "locator" : "362:16-362:41",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "Concatenate",
                            "signature" : [ ],
                            "operand" : [ {
-                              "localId" : "5045",
-                              "locator" : "353:16-353:34",
+                              "localId" : "5323",
+                              "locator" : "362:16-362:34",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "DiagnosticReport/",
                               "type" : "Literal"
                            }, {
-                              "localId" : "5048",
+                              "localId" : "5326",
                               "name" : "ToString",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "5049",
+                                 "localId" : "5327",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "5047",
-                                 "locator" : "353:38-353:41",
+                                 "localId" : "5325",
+                                 "locator" : "362:38-362:41",
                                  "resultTypeName" : "{http://hl7.org/fhir}id",
                                  "path" : "id",
                                  "scope" : "D",
@@ -11308,27 +11860,27 @@
                      }, {
                         "name" : "edited",
                         "value" : {
-                           "localId" : "5054",
-                           "locator" : "354:13-354:35",
+                           "localId" : "5332",
+                           "locator" : "363:13-363:35",
                            "name" : "HasBeenLocallyEdited",
                            "type" : "FunctionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "5056",
+                              "localId" : "5334",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "5057",
+                                 "localId" : "5335",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "signature" : [ {
-                              "localId" : "5055",
+                              "localId" : "5333",
                               "name" : "{http://hl7.org/fhir}DomainResource",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "5053",
-                              "locator" : "354:34",
+                              "localId" : "5331",
+                              "locator" : "363:34",
                               "resultTypeName" : "{http://hl7.org/fhir}DiagnosticReport",
                               "name" : "D",
                               "type" : "AliasRef"
@@ -11459,63 +12011,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4617",
+               "localId" : "4793",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4618",
+                  "localId" : "4794",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4619",
+                     "localId" : "4795",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4620",
+                        "localId" : "4796",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4621",
+                     "localId" : "4797",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4622",
+                        "localId" : "4798",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4623",
+                     "localId" : "4799",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4624",
+                        "localId" : "4800",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4801",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4802",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4625",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4803",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4626",
+                     "localId" : "4804",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4627",
+                        "localId" : "4805",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4628",
+                     "localId" : "4806",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4629",
+                        "localId" : "4807",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4630",
+                     "localId" : "4808",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4631",
+                        "localId" : "4809",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4632",
+                           "localId" : "4810",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -11529,63 +12089,71 @@
                "name" : "FormatReports",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "2597",
+                  "localId" : "2697",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2598",
+                     "localId" : "2698",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "2599",
+                        "localId" : "2699",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "2600",
+                           "localId" : "2700",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2601",
+                        "localId" : "2701",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "2602",
+                           "localId" : "2702",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2603",
+                        "localId" : "2703",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "2604",
+                           "localId" : "2704",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "2705",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "2706",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2605",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "2707",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "2606",
+                        "localId" : "2708",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "2607",
+                           "localId" : "2709",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2608",
+                        "localId" : "2710",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "2609",
+                           "localId" : "2711",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2610",
+                        "localId" : "2712",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "2611",
+                           "localId" : "2713",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2612",
+                              "localId" : "2714",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -11654,7 +12222,7 @@
                } ]
             }
          }, {
-            "localId" : "2647",
+            "localId" : "2753",
             "locator" : "238:1-239:118",
             "name" : "sDNAFITDiagnosticReportsSummary",
             "context" : "Patient",
@@ -11662,24 +12230,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "2647",
+                  "r" : "2753",
                   "s" : [ {
                      "value" : [ "","define ","sDNAFITDiagnosticReportsSummary",":\n  " ]
                   }, {
-                     "r" : "2661",
+                     "r" : "2767",
                      "s" : [ {
                         "value" : [ "FormatReports","(" ]
                      }, {
-                        "r" : "2649",
+                        "r" : "2755",
                         "s" : [ {
-                           "r" : "2648",
+                           "r" : "2754",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2649",
+                           "r" : "2755",
                            "s" : [ {
                               "value" : [ "StoolDNAFITDiagnosticReports" ]
                            } ]
@@ -11687,16 +12255,16 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2655",
+                        "r" : "2761",
                         "s" : [ {
-                           "r" : "2654",
+                           "r" : "2760",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2655",
+                           "r" : "2761",
                            "s" : [ {
                               "value" : [ "StoolDNAFITObservations" ]
                            } ]
@@ -11704,7 +12272,7 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2660",
+                        "r" : "2766",
                         "s" : [ {
                            "value" : [ "'Stool DNA FIT Test'" ]
                         } ]
@@ -11715,63 +12283,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4633",
+               "localId" : "4811",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4634",
+                  "localId" : "4812",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4635",
+                     "localId" : "4813",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4636",
+                        "localId" : "4814",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4637",
+                     "localId" : "4815",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4638",
+                        "localId" : "4816",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4639",
+                     "localId" : "4817",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4640",
+                        "localId" : "4818",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4819",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4820",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4641",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4821",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4642",
+                     "localId" : "4822",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4643",
+                        "localId" : "4823",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4644",
+                     "localId" : "4824",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4645",
+                        "localId" : "4825",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4646",
+                     "localId" : "4826",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4647",
+                        "localId" : "4827",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4648",
+                           "localId" : "4828",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -11780,68 +12356,76 @@
                }
             },
             "expression" : {
-               "localId" : "2661",
+               "localId" : "2767",
                "locator" : "239:3-239:118",
                "name" : "FormatReports",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "2667",
+                  "localId" : "2773",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2668",
+                     "localId" : "2774",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "2669",
+                        "localId" : "2775",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "2670",
+                           "localId" : "2776",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2671",
+                        "localId" : "2777",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "2672",
+                           "localId" : "2778",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2673",
+                        "localId" : "2779",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "2674",
+                           "localId" : "2780",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "2781",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "2782",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2675",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "2783",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "2676",
+                        "localId" : "2784",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "2677",
+                           "localId" : "2785",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2678",
+                        "localId" : "2786",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "2679",
+                           "localId" : "2787",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2680",
+                        "localId" : "2788",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "2681",
+                           "localId" : "2789",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2682",
+                              "localId" : "2790",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -11850,58 +12434,58 @@
                   }
                },
                "signature" : [ {
-                  "localId" : "2662",
+                  "localId" : "2768",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2663",
+                     "localId" : "2769",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2664",
+                  "localId" : "2770",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2665",
+                     "localId" : "2771",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2666",
+                  "localId" : "2772",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "2649",
+                  "localId" : "2755",
                   "locator" : "239:17-239:57",
                   "name" : "StoolDNAFITDiagnosticReports",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2652",
+                     "localId" : "2758",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2653",
+                        "localId" : "2759",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2655",
+                  "localId" : "2761",
                   "locator" : "239:60-239:95",
                   "name" : "StoolDNAFITObservations",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2658",
+                     "localId" : "2764",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2659",
+                        "localId" : "2765",
                         "name" : "{http://hl7.org/fhir}Observation",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2660",
+                  "localId" : "2766",
                   "locator" : "239:98-239:117",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -11910,7 +12494,7 @@
                } ]
             }
          }, {
-            "localId" : "2766",
+            "localId" : "2884",
             "locator" : "241:1-242:111",
             "name" : "ColonoscopyDiagnosticReportsSummary",
             "context" : "Patient",
@@ -11918,24 +12502,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "2766",
+                  "r" : "2884",
                   "s" : [ {
                      "value" : [ "","define ","ColonoscopyDiagnosticReportsSummary",":\n  " ]
                   }, {
-                     "r" : "2780",
+                     "r" : "2898",
                      "s" : [ {
                         "value" : [ "FormatReports","(" ]
                      }, {
-                        "r" : "2768",
+                        "r" : "2886",
                         "s" : [ {
-                           "r" : "2767",
+                           "r" : "2885",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2768",
+                           "r" : "2886",
                            "s" : [ {
                               "value" : [ "ColonoscopyDiagnosticReports" ]
                            } ]
@@ -11943,16 +12527,16 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2774",
+                        "r" : "2892",
                         "s" : [ {
-                           "r" : "2773",
+                           "r" : "2891",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2774",
+                           "r" : "2892",
                            "s" : [ {
                               "value" : [ "ColonoscopyObservations" ]
                            } ]
@@ -11960,7 +12544,7 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2779",
+                        "r" : "2897",
                         "s" : [ {
                            "value" : [ "'Colonoscopy'" ]
                         } ]
@@ -11971,63 +12555,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4649",
+               "localId" : "4829",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4650",
+                  "localId" : "4830",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4651",
+                     "localId" : "4831",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4652",
+                        "localId" : "4832",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4653",
+                     "localId" : "4833",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4654",
+                        "localId" : "4834",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4655",
+                     "localId" : "4835",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4656",
+                        "localId" : "4836",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4837",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4838",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4657",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4839",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4658",
+                     "localId" : "4840",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4659",
+                        "localId" : "4841",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4660",
+                     "localId" : "4842",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4661",
+                        "localId" : "4843",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4662",
+                     "localId" : "4844",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4663",
+                        "localId" : "4845",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4664",
+                           "localId" : "4846",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -12036,68 +12628,76 @@
                }
             },
             "expression" : {
-               "localId" : "2780",
+               "localId" : "2898",
                "locator" : "242:3-242:111",
                "name" : "FormatReports",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "2786",
+                  "localId" : "2904",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2787",
+                     "localId" : "2905",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "2788",
+                        "localId" : "2906",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "2789",
+                           "localId" : "2907",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2790",
+                        "localId" : "2908",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "2791",
+                           "localId" : "2909",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2792",
+                        "localId" : "2910",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "2793",
+                           "localId" : "2911",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "2912",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "2913",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2794",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "2914",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "2795",
+                        "localId" : "2915",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "2796",
+                           "localId" : "2916",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2797",
+                        "localId" : "2917",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "2798",
+                           "localId" : "2918",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2799",
+                        "localId" : "2919",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "2800",
+                           "localId" : "2920",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2801",
+                              "localId" : "2921",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -12106,58 +12706,58 @@
                   }
                },
                "signature" : [ {
-                  "localId" : "2781",
+                  "localId" : "2899",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2782",
+                     "localId" : "2900",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2783",
+                  "localId" : "2901",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2784",
+                     "localId" : "2902",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2785",
+                  "localId" : "2903",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "2768",
+                  "localId" : "2886",
                   "locator" : "242:17-242:57",
                   "name" : "ColonoscopyDiagnosticReports",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2771",
+                     "localId" : "2889",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2772",
+                        "localId" : "2890",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2774",
+                  "localId" : "2892",
                   "locator" : "242:60-242:95",
                   "name" : "ColonoscopyObservations",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2777",
+                     "localId" : "2895",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2778",
+                        "localId" : "2896",
                         "name" : "{http://hl7.org/fhir}Observation",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2779",
+                  "localId" : "2897",
                   "locator" : "242:98-242:110",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -12166,7 +12766,7 @@
                } ]
             }
          }, {
-            "localId" : "2885",
+            "localId" : "3015",
             "locator" : "244:1-245:121",
             "name" : "CTColonographyDiagnosticReportsSummary",
             "context" : "Patient",
@@ -12174,24 +12774,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "2885",
+                  "r" : "3015",
                   "s" : [ {
                      "value" : [ "","define ","CTColonographyDiagnosticReportsSummary",":\n  " ]
                   }, {
-                     "r" : "2899",
+                     "r" : "3029",
                      "s" : [ {
                         "value" : [ "FormatReports","(" ]
                      }, {
-                        "r" : "2887",
+                        "r" : "3017",
                         "s" : [ {
-                           "r" : "2886",
+                           "r" : "3016",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2887",
+                           "r" : "3017",
                            "s" : [ {
                               "value" : [ "CTColonographyDiagnosticReports" ]
                            } ]
@@ -12199,16 +12799,16 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2893",
+                        "r" : "3023",
                         "s" : [ {
-                           "r" : "2892",
+                           "r" : "3022",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "2893",
+                           "r" : "3023",
                            "s" : [ {
                               "value" : [ "CTColonographyObservations" ]
                            } ]
@@ -12216,7 +12816,7 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "2898",
+                        "r" : "3028",
                         "s" : [ {
                            "value" : [ "'CT Colonography'" ]
                         } ]
@@ -12227,63 +12827,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4665",
+               "localId" : "4847",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4666",
+                  "localId" : "4848",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4667",
+                     "localId" : "4849",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4668",
+                        "localId" : "4850",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4669",
+                     "localId" : "4851",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4670",
+                        "localId" : "4852",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4671",
+                     "localId" : "4853",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4672",
+                        "localId" : "4854",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4855",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4856",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4673",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4857",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4674",
+                     "localId" : "4858",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4675",
+                        "localId" : "4859",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4676",
+                     "localId" : "4860",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4677",
+                        "localId" : "4861",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4678",
+                     "localId" : "4862",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4679",
+                        "localId" : "4863",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4680",
+                           "localId" : "4864",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -12292,68 +12900,76 @@
                }
             },
             "expression" : {
-               "localId" : "2899",
+               "localId" : "3029",
                "locator" : "245:3-245:121",
                "name" : "FormatReports",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "2905",
+                  "localId" : "3035",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2906",
+                     "localId" : "3036",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "2907",
+                        "localId" : "3037",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "2908",
+                           "localId" : "3038",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2909",
+                        "localId" : "3039",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "2910",
+                           "localId" : "3040",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2911",
+                        "localId" : "3041",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "2912",
+                           "localId" : "3042",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "3043",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "3044",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2913",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "3045",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "2914",
+                        "localId" : "3046",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "2915",
+                           "localId" : "3047",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2916",
+                        "localId" : "3048",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "2917",
+                           "localId" : "3049",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "2918",
+                        "localId" : "3050",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "2919",
+                           "localId" : "3051",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2920",
+                              "localId" : "3052",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -12362,58 +12978,58 @@
                   }
                },
                "signature" : [ {
-                  "localId" : "2900",
+                  "localId" : "3030",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2901",
+                     "localId" : "3031",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2902",
+                  "localId" : "3032",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "2903",
+                     "localId" : "3033",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "2904",
+                  "localId" : "3034",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "2887",
+                  "localId" : "3017",
                   "locator" : "245:17-245:60",
                   "name" : "CTColonographyDiagnosticReports",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2890",
+                     "localId" : "3020",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2891",
+                        "localId" : "3021",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2893",
+                  "localId" : "3023",
                   "locator" : "245:63-245:101",
                   "name" : "CTColonographyObservations",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "2896",
+                     "localId" : "3026",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "2897",
+                        "localId" : "3027",
                         "name" : "{http://hl7.org/fhir}Observation",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "2898",
+                  "localId" : "3028",
                   "locator" : "245:104-245:120",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -12422,7 +13038,7 @@
                } ]
             }
          }, {
-            "localId" : "3037",
+            "localId" : "3183",
             "locator" : "247:1-248:114",
             "name" : "FlexSigDiagnosticReportsSummary",
             "context" : "Patient",
@@ -12430,24 +13046,24 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3037",
+                  "r" : "3183",
                   "s" : [ {
                      "value" : [ "","define ","FlexSigDiagnosticReportsSummary",":\n  " ]
                   }, {
-                     "r" : "3051",
+                     "r" : "3197",
                      "s" : [ {
                         "value" : [ "FormatReports","(" ]
                      }, {
-                        "r" : "3039",
+                        "r" : "3185",
                         "s" : [ {
-                           "r" : "3038",
+                           "r" : "3184",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3039",
+                           "r" : "3185",
                            "s" : [ {
                               "value" : [ "FlexSigDiagnosticReports" ]
                            } ]
@@ -12455,16 +13071,16 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "3045",
+                        "r" : "3191",
                         "s" : [ {
-                           "r" : "3044",
+                           "r" : "3190",
                            "s" : [ {
                               "value" : [ "DataElements" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "3045",
+                           "r" : "3191",
                            "s" : [ {
                               "value" : [ "FlexSigObservations" ]
                            } ]
@@ -12472,7 +13088,7 @@
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "3050",
+                        "r" : "3196",
                         "s" : [ {
                            "value" : [ "'Flexible Sigmoidoscopy'" ]
                         } ]
@@ -12483,63 +13099,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4681",
+               "localId" : "4865",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4682",
+                  "localId" : "4866",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4683",
+                     "localId" : "4867",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4684",
+                        "localId" : "4868",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4685",
+                     "localId" : "4869",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4686",
+                        "localId" : "4870",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4687",
+                     "localId" : "4871",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4688",
+                        "localId" : "4872",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4873",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4874",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4689",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4875",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4690",
+                     "localId" : "4876",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4691",
+                        "localId" : "4877",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4692",
+                     "localId" : "4878",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4693",
+                        "localId" : "4879",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4694",
+                     "localId" : "4880",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4695",
+                        "localId" : "4881",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4696",
+                           "localId" : "4882",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -12548,68 +13172,76 @@
                }
             },
             "expression" : {
-               "localId" : "3051",
+               "localId" : "3197",
                "locator" : "248:3-248:114",
                "name" : "FormatReports",
                "type" : "FunctionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "3057",
+                  "localId" : "3203",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3058",
+                     "localId" : "3204",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3059",
+                        "localId" : "3205",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3060",
+                           "localId" : "3206",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3061",
+                        "localId" : "3207",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "3062",
+                           "localId" : "3208",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3063",
+                        "localId" : "3209",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "3064",
+                           "localId" : "3210",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "3211",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "3212",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3065",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "3213",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "3066",
+                        "localId" : "3214",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "3067",
+                           "localId" : "3215",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3068",
+                        "localId" : "3216",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "3069",
+                           "localId" : "3217",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3070",
+                        "localId" : "3218",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "3071",
+                           "localId" : "3219",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3072",
+                              "localId" : "3220",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -12618,58 +13250,58 @@
                   }
                },
                "signature" : [ {
-                  "localId" : "3052",
+                  "localId" : "3198",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3053",
+                     "localId" : "3199",
                      "name" : "{http://hl7.org/fhir}DiagnosticReport",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "3054",
+                  "localId" : "3200",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3055",
+                     "localId" : "3201",
                      "name" : "{http://hl7.org/fhir}Observation",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "3056",
+                  "localId" : "3202",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "3039",
+                  "localId" : "3185",
                   "locator" : "248:17-248:53",
                   "name" : "FlexSigDiagnosticReports",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3042",
+                     "localId" : "3188",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3043",
+                        "localId" : "3189",
                         "name" : "{http://hl7.org/fhir}DiagnosticReport",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "3045",
+                  "localId" : "3191",
                   "locator" : "248:56-248:87",
                   "name" : "FlexSigObservations",
                   "libraryName" : "DataElements",
                   "type" : "ExpressionRef",
                   "resultTypeSpecifier" : {
-                     "localId" : "3048",
+                     "localId" : "3194",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3049",
+                        "localId" : "3195",
                         "name" : "{http://hl7.org/fhir}Observation",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "3050",
+                  "localId" : "3196",
                   "locator" : "248:90-248:113",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -12690,31 +13322,31 @@
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// PERTINENT DIAGNOSTIC REPORTS\n//------------------------------------------------------------------------------\n\n","define ","DiagnosticReportsSummary",":\n  " ]
                   }, {
-                     "r" : "3195",
+                     "r" : "3357",
                      "s" : [ {
                         "s" : [ {
                            "r" : "2445",
                            "s" : [ {
-                              "r" : "3106",
+                              "r" : "3258",
                               "s" : [ {
                                  "value" : [ "(\n    " ]
                               }, {
-                                 "r" : "3106",
+                                 "r" : "3258",
                                  "s" : [ {
-                                    "r" : "2987",
+                                    "r" : "3127",
                                     "s" : [ {
-                                       "r" : "2835",
+                                       "r" : "2959",
                                        "s" : [ {
-                                          "r" : "2716",
+                                          "r" : "2828",
                                           "s" : [ {
-                                             "r" : "2629",
+                                             "r" : "2733",
                                              "s" : [ {
                                                 "value" : [ "FOBTDiagnosticReportsSummary" ]
                                              } ]
                                           }, {
                                              "value" : [ "\n    union " ]
                                           }, {
-                                             "r" : "2699",
+                                             "r" : "2809",
                                              "s" : [ {
                                                 "value" : [ "sDNAFITDiagnosticReportsSummary" ]
                                              } ]
@@ -12722,7 +13354,7 @@
                                        }, {
                                           "value" : [ "\n    union " ]
                                        }, {
-                                          "r" : "2818",
+                                          "r" : "2940",
                                           "s" : [ {
                                              "value" : [ "ColonoscopyDiagnosticReportsSummary" ]
                                           } ]
@@ -12730,7 +13362,7 @@
                                     }, {
                                        "value" : [ "\n    union " ]
                                     }, {
-                                       "r" : "2937",
+                                       "r" : "3071",
                                        "s" : [ {
                                           "value" : [ "CTColonographyDiagnosticReportsSummary" ]
                                        } ]
@@ -12738,7 +13370,7 @@
                                  }, {
                                     "value" : [ "\n    union " ]
                                  }, {
-                                    "r" : "3089",
+                                    "r" : "3239",
                                     "s" : [ {
                                        "value" : [ "FlexSigDiagnosticReportsSummary" ]
                                     } ]
@@ -12753,13 +13385,13 @@
                      }, {
                         "value" : [ "\n  " ]
                      }, {
-                        "r" : "3189",
+                        "r" : "3351",
                         "s" : [ {
                            "value" : [ "sort by " ]
                         }, {
-                           "r" : "3188",
+                           "r" : "3350",
                            "s" : [ {
-                              "r" : "3187",
+                              "r" : "3349",
                               "s" : [ {
                                  "value" : [ "date" ]
                               } ]
@@ -12772,63 +13404,71 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4601",
+               "localId" : "4775",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4602",
+                  "localId" : "4776",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4603",
+                     "localId" : "4777",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4604",
+                        "localId" : "4778",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4605",
+                     "localId" : "4779",
                      "name" : "longName",
                      "elementType" : {
-                        "localId" : "4606",
+                        "localId" : "4780",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4607",
+                     "localId" : "4781",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4608",
+                        "localId" : "4782",
+                        "name" : "{http://hl7.org/fhir}string",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "4783",
+                     "name" : "longValue",
+                     "elementType" : {
+                        "localId" : "4784",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4609",
-                           "name" : "{http://hl7.org/fhir}CodeableConcept",
+                           "localId" : "4785",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier"
                         }
                      }
                   }, {
-                     "localId" : "4610",
+                     "localId" : "4786",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4611",
+                        "localId" : "4787",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4612",
+                     "localId" : "4788",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4613",
+                        "localId" : "4789",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4614",
+                     "localId" : "4790",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4615",
+                        "localId" : "4791",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4616",
+                           "localId" : "4792",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -12837,67 +13477,75 @@
                }
             },
             "expression" : {
-               "localId" : "3195",
+               "localId" : "3357",
                "locator" : "226:3-233:19",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3196",
+                  "localId" : "3358",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3197",
+                     "localId" : "3359",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3198",
+                        "localId" : "3360",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3199",
+                           "localId" : "3361",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3200",
+                        "localId" : "3362",
                         "name" : "longName",
                         "elementType" : {
-                           "localId" : "3201",
+                           "localId" : "3363",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3202",
+                        "localId" : "3364",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "3203",
+                           "localId" : "3365",
+                           "name" : "{http://hl7.org/fhir}string",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }, {
+                        "localId" : "3366",
+                        "name" : "longValue",
+                        "elementType" : {
+                           "localId" : "3367",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3204",
-                              "name" : "{http://hl7.org/fhir}CodeableConcept",
+                              "localId" : "3368",
+                              "name" : "{http://hl7.org/fhir}string",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "3205",
+                        "localId" : "3369",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "3206",
+                           "localId" : "3370",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3207",
+                        "localId" : "3371",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "3208",
+                           "localId" : "3372",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3209",
+                        "localId" : "3373",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "3210",
+                           "localId" : "3374",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3211",
+                              "localId" : "3375",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -12910,63 +13558,71 @@
                   "locator" : "226:3-232:5",
                   "alias" : "D",
                   "resultTypeSpecifier" : {
-                     "localId" : "3171",
+                     "localId" : "3331",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3172",
+                        "localId" : "3332",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3173",
+                           "localId" : "3333",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3174",
+                              "localId" : "3334",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3175",
+                           "localId" : "3335",
                            "name" : "longName",
                            "elementType" : {
-                              "localId" : "3176",
+                              "localId" : "3336",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3177",
+                           "localId" : "3337",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "3178",
+                              "localId" : "3338",
+                              "name" : "{http://hl7.org/fhir}string",
+                              "type" : "NamedTypeSpecifier"
+                           }
+                        }, {
+                           "localId" : "3339",
+                           "name" : "longValue",
+                           "elementType" : {
+                              "localId" : "3340",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3179",
-                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "localId" : "3341",
+                                 "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }
                         }, {
-                           "localId" : "3180",
+                           "localId" : "3342",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "3181",
+                              "localId" : "3343",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3182",
+                           "localId" : "3344",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "3183",
+                              "localId" : "3345",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3184",
+                           "localId" : "3346",
                            "name" : "edited",
                            "elementType" : {
-                              "localId" : "3185",
+                              "localId" : "3347",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3186",
+                                 "localId" : "3348",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -12975,67 +13631,75 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3106",
+                     "localId" : "3258",
                      "locator" : "226:3-232:3",
                      "type" : "Union",
                      "resultTypeSpecifier" : {
-                        "localId" : "3155",
+                        "localId" : "3313",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3156",
+                           "localId" : "3314",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3157",
+                              "localId" : "3315",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3158",
+                                 "localId" : "3316",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3159",
+                              "localId" : "3317",
                               "name" : "longName",
                               "elementType" : {
-                                 "localId" : "3160",
+                                 "localId" : "3318",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3161",
+                              "localId" : "3319",
                               "name" : "value",
                               "elementType" : {
-                                 "localId" : "3162",
+                                 "localId" : "3320",
+                                 "name" : "{http://hl7.org/fhir}string",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }, {
+                              "localId" : "3321",
+                              "name" : "longValue",
+                              "elementType" : {
+                                 "localId" : "3322",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3163",
-                                    "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                    "localId" : "3323",
+                                    "name" : "{http://hl7.org/fhir}string",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }
                            }, {
-                              "localId" : "3164",
+                              "localId" : "3324",
                               "name" : "date",
                               "elementType" : {
-                                 "localId" : "3165",
+                                 "localId" : "3325",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3166",
+                              "localId" : "3326",
                               "name" : "reference",
                               "elementType" : {
-                                 "localId" : "3167",
+                                 "localId" : "3327",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3168",
+                              "localId" : "3328",
                               "name" : "edited",
                               "elementType" : {
-                                 "localId" : "3169",
+                                 "localId" : "3329",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3170",
+                                    "localId" : "3330",
                                     "name" : "{http://hl7.org/fhir}Extension",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -13044,63 +13708,71 @@
                         }
                      },
                      "signature" : [ {
-                        "localId" : "3107",
+                        "localId" : "3259",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3108",
+                           "localId" : "3260",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3109",
+                              "localId" : "3261",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3110",
+                                 "localId" : "3262",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3111",
+                              "localId" : "3263",
                               "name" : "longName",
                               "elementType" : {
-                                 "localId" : "3112",
+                                 "localId" : "3264",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3113",
+                              "localId" : "3265",
                               "name" : "value",
                               "elementType" : {
-                                 "localId" : "3114",
+                                 "localId" : "3266",
+                                 "name" : "{http://hl7.org/fhir}string",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }, {
+                              "localId" : "3267",
+                              "name" : "longValue",
+                              "elementType" : {
+                                 "localId" : "3268",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3115",
-                                    "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                    "localId" : "3269",
+                                    "name" : "{http://hl7.org/fhir}string",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }
                            }, {
-                              "localId" : "3116",
+                              "localId" : "3270",
                               "name" : "date",
                               "elementType" : {
-                                 "localId" : "3117",
+                                 "localId" : "3271",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3118",
+                              "localId" : "3272",
                               "name" : "reference",
                               "elementType" : {
-                                 "localId" : "3119",
+                                 "localId" : "3273",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3120",
+                              "localId" : "3274",
                               "name" : "edited",
                               "elementType" : {
-                                 "localId" : "3121",
+                                 "localId" : "3275",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3122",
+                                    "localId" : "3276",
                                     "name" : "{http://hl7.org/fhir}Extension",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -13108,63 +13780,71 @@
                            } ]
                         }
                      }, {
-                        "localId" : "3123",
+                        "localId" : "3277",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3124",
+                           "localId" : "3278",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3125",
+                              "localId" : "3279",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3126",
+                                 "localId" : "3280",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3127",
+                              "localId" : "3281",
                               "name" : "longName",
                               "elementType" : {
-                                 "localId" : "3128",
+                                 "localId" : "3282",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3129",
+                              "localId" : "3283",
                               "name" : "value",
                               "elementType" : {
-                                 "localId" : "3130",
+                                 "localId" : "3284",
+                                 "name" : "{http://hl7.org/fhir}string",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }, {
+                              "localId" : "3285",
+                              "name" : "longValue",
+                              "elementType" : {
+                                 "localId" : "3286",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3131",
-                                    "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                    "localId" : "3287",
+                                    "name" : "{http://hl7.org/fhir}string",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }
                            }, {
-                              "localId" : "3132",
+                              "localId" : "3288",
                               "name" : "date",
                               "elementType" : {
-                                 "localId" : "3133",
+                                 "localId" : "3289",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3134",
+                              "localId" : "3290",
                               "name" : "reference",
                               "elementType" : {
-                                 "localId" : "3135",
+                                 "localId" : "3291",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3136",
+                              "localId" : "3292",
                               "name" : "edited",
                               "elementType" : {
-                                 "localId" : "3137",
+                                 "localId" : "3293",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3138",
+                                    "localId" : "3294",
                                     "name" : "{http://hl7.org/fhir}Extension",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -13173,67 +13853,75 @@
                         }
                      } ],
                      "operand" : [ {
-                        "localId" : "2987",
+                        "localId" : "3127",
                         "locator" : "227:5-230:48",
                         "type" : "Union",
                         "resultTypeSpecifier" : {
-                           "localId" : "3020",
+                           "localId" : "3164",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3021",
+                              "localId" : "3165",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3022",
+                                 "localId" : "3166",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "3023",
+                                    "localId" : "3167",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3024",
+                                 "localId" : "3168",
                                  "name" : "longName",
                                  "elementType" : {
-                                    "localId" : "3025",
+                                    "localId" : "3169",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3026",
+                                 "localId" : "3170",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "3027",
+                                    "localId" : "3171",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }, {
+                                 "localId" : "3172",
+                                 "name" : "longValue",
+                                 "elementType" : {
+                                    "localId" : "3173",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3028",
-                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "localId" : "3174",
+                                       "name" : "{http://hl7.org/fhir}string",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "3029",
+                                 "localId" : "3175",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "3030",
+                                    "localId" : "3176",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3031",
+                                 "localId" : "3177",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "3032",
+                                    "localId" : "3178",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3033",
+                                 "localId" : "3179",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "3034",
+                                    "localId" : "3180",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3035",
+                                       "localId" : "3181",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -13242,63 +13930,71 @@
                            }
                         },
                         "signature" : [ {
-                           "localId" : "2988",
+                           "localId" : "3128",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "2989",
+                              "localId" : "3129",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "2990",
+                                 "localId" : "3130",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "2991",
+                                    "localId" : "3131",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "2992",
+                                 "localId" : "3132",
                                  "name" : "longName",
                                  "elementType" : {
-                                    "localId" : "2993",
+                                    "localId" : "3133",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "2994",
+                                 "localId" : "3134",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "2995",
+                                    "localId" : "3135",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }, {
+                                 "localId" : "3136",
+                                 "name" : "longValue",
+                                 "elementType" : {
+                                    "localId" : "3137",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "2996",
-                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "localId" : "3138",
+                                       "name" : "{http://hl7.org/fhir}string",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "2997",
+                                 "localId" : "3139",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "2998",
+                                    "localId" : "3140",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "2999",
+                                 "localId" : "3141",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "3000",
+                                    "localId" : "3142",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3001",
+                                 "localId" : "3143",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "3002",
+                                    "localId" : "3144",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3003",
+                                       "localId" : "3145",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -13306,63 +14002,71 @@
                               } ]
                            }
                         }, {
-                           "localId" : "3004",
+                           "localId" : "3146",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3005",
+                              "localId" : "3147",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3006",
+                                 "localId" : "3148",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "3007",
+                                    "localId" : "3149",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3008",
+                                 "localId" : "3150",
                                  "name" : "longName",
                                  "elementType" : {
-                                    "localId" : "3009",
+                                    "localId" : "3151",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3010",
+                                 "localId" : "3152",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "3011",
+                                    "localId" : "3153",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }, {
+                                 "localId" : "3154",
+                                 "name" : "longValue",
+                                 "elementType" : {
+                                    "localId" : "3155",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3012",
-                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "localId" : "3156",
+                                       "name" : "{http://hl7.org/fhir}string",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "3013",
+                                 "localId" : "3157",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "3014",
+                                    "localId" : "3158",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3015",
+                                 "localId" : "3159",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "3016",
+                                    "localId" : "3160",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3017",
+                                 "localId" : "3161",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "3018",
+                                    "localId" : "3162",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3019",
+                                       "localId" : "3163",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -13371,67 +14075,75 @@
                            }
                         } ],
                         "operand" : [ {
-                           "localId" : "2716",
+                           "localId" : "2828",
                            "locator" : "227:5-228:41",
                            "type" : "Union",
                            "resultTypeSpecifier" : {
-                              "localId" : "2749",
+                              "localId" : "2865",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "2750",
+                                 "localId" : "2866",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "2751",
+                                    "localId" : "2867",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "2752",
+                                       "localId" : "2868",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2753",
+                                    "localId" : "2869",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "2754",
+                                       "localId" : "2870",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2755",
+                                    "localId" : "2871",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "2756",
+                                       "localId" : "2872",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "2873",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "2874",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2757",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "2875",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "2758",
+                                    "localId" : "2876",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "2759",
+                                       "localId" : "2877",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2760",
+                                    "localId" : "2878",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "2761",
+                                       "localId" : "2879",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2762",
+                                    "localId" : "2880",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "2763",
+                                       "localId" : "2881",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2764",
+                                          "localId" : "2882",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -13440,63 +14152,71 @@
                               }
                            },
                            "signature" : [ {
-                              "localId" : "2717",
+                              "localId" : "2829",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "2718",
+                                 "localId" : "2830",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "2719",
+                                    "localId" : "2831",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "2720",
+                                       "localId" : "2832",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2721",
+                                    "localId" : "2833",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "2722",
+                                       "localId" : "2834",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2723",
+                                    "localId" : "2835",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "2724",
+                                       "localId" : "2836",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "2837",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "2838",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2725",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "2839",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "2726",
+                                    "localId" : "2840",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "2727",
+                                       "localId" : "2841",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2728",
+                                    "localId" : "2842",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "2729",
+                                       "localId" : "2843",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2730",
+                                    "localId" : "2844",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "2731",
+                                       "localId" : "2845",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2732",
+                                          "localId" : "2846",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -13504,63 +14224,71 @@
                                  } ]
                               }
                            }, {
-                              "localId" : "2733",
+                              "localId" : "2847",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "2734",
+                                 "localId" : "2848",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "2735",
+                                    "localId" : "2849",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "2736",
+                                       "localId" : "2850",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2737",
+                                    "localId" : "2851",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "2738",
+                                       "localId" : "2852",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2739",
+                                    "localId" : "2853",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "2740",
+                                       "localId" : "2854",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "2855",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "2856",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2741",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "2857",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "2742",
+                                    "localId" : "2858",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "2743",
+                                       "localId" : "2859",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2744",
+                                    "localId" : "2860",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "2745",
+                                       "localId" : "2861",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2746",
+                                    "localId" : "2862",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "2747",
+                                       "localId" : "2863",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2748",
+                                          "localId" : "2864",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -13569,68 +14297,76 @@
                               }
                            } ],
                            "operand" : [ {
-                              "localId" : "2629",
+                              "localId" : "2733",
                               "locator" : "227:5-227:32",
                               "name" : "FOBTDiagnosticReportsSummary",
                               "type" : "ExpressionRef",
                               "resultTypeSpecifier" : {
-                                 "localId" : "2630",
+                                 "localId" : "2734",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "2631",
+                                    "localId" : "2735",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "2632",
+                                       "localId" : "2736",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "2633",
+                                          "localId" : "2737",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2634",
+                                       "localId" : "2738",
                                        "name" : "longName",
                                        "elementType" : {
-                                          "localId" : "2635",
+                                          "localId" : "2739",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2636",
+                                       "localId" : "2740",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "2637",
+                                          "localId" : "2741",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }, {
+                                       "localId" : "2742",
+                                       "name" : "longValue",
+                                       "elementType" : {
+                                          "localId" : "2743",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2638",
-                                             "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                             "localId" : "2744",
+                                             "name" : "{http://hl7.org/fhir}string",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        }
                                     }, {
-                                       "localId" : "2639",
+                                       "localId" : "2745",
                                        "name" : "date",
                                        "elementType" : {
-                                          "localId" : "2640",
+                                          "localId" : "2746",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2641",
+                                       "localId" : "2747",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "2642",
+                                          "localId" : "2748",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2643",
+                                       "localId" : "2749",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "2644",
+                                          "localId" : "2750",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2645",
+                                             "localId" : "2751",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -13639,68 +14375,76 @@
                                  }
                               }
                            }, {
-                              "localId" : "2699",
+                              "localId" : "2809",
                               "locator" : "228:11-228:41",
                               "name" : "sDNAFITDiagnosticReportsSummary",
                               "type" : "ExpressionRef",
                               "resultTypeSpecifier" : {
-                                 "localId" : "2700",
+                                 "localId" : "2810",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "2701",
+                                    "localId" : "2811",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "2702",
+                                       "localId" : "2812",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "2703",
+                                          "localId" : "2813",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2704",
+                                       "localId" : "2814",
                                        "name" : "longName",
                                        "elementType" : {
-                                          "localId" : "2705",
+                                          "localId" : "2815",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2706",
+                                       "localId" : "2816",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "2707",
+                                          "localId" : "2817",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }, {
+                                       "localId" : "2818",
+                                       "name" : "longValue",
+                                       "elementType" : {
+                                          "localId" : "2819",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2708",
-                                             "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                             "localId" : "2820",
+                                             "name" : "{http://hl7.org/fhir}string",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        }
                                     }, {
-                                       "localId" : "2709",
+                                       "localId" : "2821",
                                        "name" : "date",
                                        "elementType" : {
-                                          "localId" : "2710",
+                                          "localId" : "2822",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2711",
+                                       "localId" : "2823",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "2712",
+                                          "localId" : "2824",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2713",
+                                       "localId" : "2825",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "2714",
+                                          "localId" : "2826",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2715",
+                                             "localId" : "2827",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -13710,66 +14454,74 @@
                               }
                            } ]
                         }, {
-                           "localId" : "2954",
+                           "localId" : "3090",
                            "type" : "Union",
                            "signature" : [ {
-                              "localId" : "2955",
+                              "localId" : "3091",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "2956",
+                                 "localId" : "3092",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "2957",
+                                    "localId" : "3093",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "2958",
+                                       "localId" : "3094",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2959",
+                                    "localId" : "3095",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "2960",
+                                       "localId" : "3096",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2961",
+                                    "localId" : "3097",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "2962",
+                                       "localId" : "3098",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "3099",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "3100",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2963",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "3101",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "2964",
+                                    "localId" : "3102",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "2965",
+                                       "localId" : "3103",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2966",
+                                    "localId" : "3104",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "2967",
+                                       "localId" : "3105",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2968",
+                                    "localId" : "3106",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "2969",
+                                       "localId" : "3107",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2970",
+                                          "localId" : "3108",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -13777,63 +14529,71 @@
                                  } ]
                               }
                            }, {
-                              "localId" : "2971",
+                              "localId" : "3109",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "2972",
+                                 "localId" : "3110",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "2973",
+                                    "localId" : "3111",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "2974",
+                                       "localId" : "3112",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2975",
+                                    "localId" : "3113",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "2976",
+                                       "localId" : "3114",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2977",
+                                    "localId" : "3115",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "2978",
+                                       "localId" : "3116",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "3117",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "3118",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2979",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "3119",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "2980",
+                                    "localId" : "3120",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "2981",
+                                       "localId" : "3121",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2982",
+                                    "localId" : "3122",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "2983",
+                                       "localId" : "3123",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "2984",
+                                    "localId" : "3124",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "2985",
+                                       "localId" : "3125",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "2986",
+                                          "localId" : "3126",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -13842,68 +14602,76 @@
                               }
                            } ],
                            "operand" : [ {
-                              "localId" : "2818",
+                              "localId" : "2940",
                               "locator" : "229:11-229:45",
                               "name" : "ColonoscopyDiagnosticReportsSummary",
                               "type" : "ExpressionRef",
                               "resultTypeSpecifier" : {
-                                 "localId" : "2819",
+                                 "localId" : "2941",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "2820",
+                                    "localId" : "2942",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "2821",
+                                       "localId" : "2943",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "2822",
+                                          "localId" : "2944",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2823",
+                                       "localId" : "2945",
                                        "name" : "longName",
                                        "elementType" : {
-                                          "localId" : "2824",
+                                          "localId" : "2946",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2825",
+                                       "localId" : "2947",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "2826",
+                                          "localId" : "2948",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }, {
+                                       "localId" : "2949",
+                                       "name" : "longValue",
+                                       "elementType" : {
+                                          "localId" : "2950",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2827",
-                                             "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                             "localId" : "2951",
+                                             "name" : "{http://hl7.org/fhir}string",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        }
                                     }, {
-                                       "localId" : "2828",
+                                       "localId" : "2952",
                                        "name" : "date",
                                        "elementType" : {
-                                          "localId" : "2829",
+                                          "localId" : "2953",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2830",
+                                       "localId" : "2954",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "2831",
+                                          "localId" : "2955",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2832",
+                                       "localId" : "2956",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "2833",
+                                          "localId" : "2957",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2834",
+                                             "localId" : "2958",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -13912,68 +14680,76 @@
                                  }
                               }
                            }, {
-                              "localId" : "2937",
+                              "localId" : "3071",
                               "locator" : "230:11-230:48",
                               "name" : "CTColonographyDiagnosticReportsSummary",
                               "type" : "ExpressionRef",
                               "resultTypeSpecifier" : {
-                                 "localId" : "2938",
+                                 "localId" : "3072",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "2939",
+                                    "localId" : "3073",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "2940",
+                                       "localId" : "3074",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "2941",
+                                          "localId" : "3075",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2942",
+                                       "localId" : "3076",
                                        "name" : "longName",
                                        "elementType" : {
-                                          "localId" : "2943",
+                                          "localId" : "3077",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2944",
+                                       "localId" : "3078",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "2945",
+                                          "localId" : "3079",
+                                          "name" : "{http://hl7.org/fhir}string",
+                                          "type" : "NamedTypeSpecifier"
+                                       }
+                                    }, {
+                                       "localId" : "3080",
+                                       "name" : "longValue",
+                                       "elementType" : {
+                                          "localId" : "3081",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2946",
-                                             "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                             "localId" : "3082",
+                                             "name" : "{http://hl7.org/fhir}string",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        }
                                     }, {
-                                       "localId" : "2947",
+                                       "localId" : "3083",
                                        "name" : "date",
                                        "elementType" : {
-                                          "localId" : "2948",
+                                          "localId" : "3084",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2949",
+                                       "localId" : "3085",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "2950",
+                                          "localId" : "3086",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "2951",
+                                       "localId" : "3087",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "2952",
+                                          "localId" : "3088",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "2953",
+                                             "localId" : "3089",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -13984,68 +14760,76 @@
                            } ]
                         } ]
                      }, {
-                        "localId" : "3089",
+                        "localId" : "3239",
                         "locator" : "231:11-231:41",
                         "name" : "FlexSigDiagnosticReportsSummary",
                         "type" : "ExpressionRef",
                         "resultTypeSpecifier" : {
-                           "localId" : "3090",
+                           "localId" : "3240",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3091",
+                              "localId" : "3241",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "3092",
+                                 "localId" : "3242",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "3093",
+                                    "localId" : "3243",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3094",
+                                 "localId" : "3244",
                                  "name" : "longName",
                                  "elementType" : {
-                                    "localId" : "3095",
+                                    "localId" : "3245",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3096",
+                                 "localId" : "3246",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "3097",
+                                    "localId" : "3247",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }, {
+                                 "localId" : "3248",
+                                 "name" : "longValue",
+                                 "elementType" : {
+                                    "localId" : "3249",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3098",
-                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "localId" : "3250",
+                                       "name" : "{http://hl7.org/fhir}string",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "3099",
+                                 "localId" : "3251",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "3100",
+                                    "localId" : "3252",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3101",
+                                 "localId" : "3253",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "3102",
+                                    "localId" : "3254",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3103",
+                                 "localId" : "3255",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "3104",
+                                    "localId" : "3256",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3105",
+                                       "localId" : "3257",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -14059,10 +14843,10 @@
                "let" : [ ],
                "relationship" : [ ],
                "sort" : {
-                  "localId" : "3189",
+                  "localId" : "3351",
                   "locator" : "233:3-233:19",
                   "by" : [ {
-                     "localId" : "3188",
+                     "localId" : "3350",
                      "locator" : "233:11-233:19",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "direction" : "desc",
@@ -14072,7 +14856,7 @@
                }
             }
          }, {
-            "localId" : "3249",
+            "localId" : "3417",
             "locator" : "262:1-263:45",
             "name" : "PertinentEncounters",
             "context" : "Patient",
@@ -14080,20 +14864,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3249",
+                  "r" : "3417",
                   "s" : [ {
                      "value" : [ "//TODO: These are in Breast, could consider equivalents needed for colorectal - like polypectomy?\n//define BiopsyDiagnosticReportsSummary:\n//  FormatReports(DataElements.BiopsyDiagnosticReports, DataElements.BiopsyObservations, 'Breast Biopsy')  \n\n//define IncompleteBiopsyDiagnosticReportsSummary:\n//  FormatReports(ScreeningTestIncomplete.IncompleteScreeningPathology, DataElements.BiopsyObservations, 'Breast Biopsy')    \n\n//------------------------------------------------------------------------------\n// PERTINENT ENCOUNTERS\n//------------------------------------------------------------------------------\n\n","define ","PertinentEncounters",":\n  " ]
                   }, {
-                     "r" : "3251",
+                     "r" : "3419",
                      "s" : [ {
-                        "r" : "3250",
+                        "r" : "3418",
                         "s" : [ {
                            "value" : [ "DataElements" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "3251",
+                        "r" : "3419",
                         "s" : [ {
                            "value" : [ "AllColorectalSymptomEncounters" ]
                         } ]
@@ -14102,32 +14886,32 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4697",
+               "localId" : "4883",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4698",
+                  "localId" : "4884",
                   "name" : "{http://hl7.org/fhir}Encounter",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3251",
+               "localId" : "3419",
                "locator" : "263:3-263:45",
                "name" : "AllColorectalSymptomEncounters",
                "libraryName" : "DataElements",
                "type" : "ExpressionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "3254",
+                  "localId" : "3422",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3255",
+                     "localId" : "3423",
                      "name" : "{http://hl7.org/fhir}Encounter",
                      "type" : "NamedTypeSpecifier"
                   }
                }
             }
          }, {
-            "localId" : "3246",
+            "localId" : "3414",
             "locator" : "265:1-274:3",
             "name" : "PertinentEncountersSummary",
             "context" : "Patient",
@@ -14135,20 +14919,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3246",
+                  "r" : "3414",
                   "s" : [ {
                      "value" : [ "","define ","PertinentEncountersSummary",":\n  " ]
                   }, {
-                     "r" : "3336",
+                     "r" : "3504",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3247",
+                           "r" : "3415",
                            "s" : [ {
-                              "r" : "3258",
+                              "r" : "3426",
                               "s" : [ {
                                  "value" : [ "(" ]
                               }, {
-                                 "r" : "3258",
+                                 "r" : "3426",
                                  "s" : [ {
                                     "value" : [ "PertinentEncounters" ]
                                  } ]
@@ -14162,48 +14946,48 @@
                      }, {
                         "value" : [ "\n  " ]
                      }, {
-                        "r" : "3265",
+                        "r" : "3433",
                         "s" : [ {
                            "value" : [ "return " ]
                         }, {
-                           "r" : "3266",
+                           "r" : "3434",
                            "s" : [ {
                               "value" : [ "{\n    " ]
                            }, {
                               "s" : [ {
                                  "value" : [ "name",": " ]
                               }, {
-                                 "r" : "3279",
+                                 "r" : "3447",
                                  "s" : [ {
-                                    "r" : "3267",
+                                    "r" : "3435",
                                     "s" : [ {
                                        "value" : [ "Common" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3279",
+                                    "r" : "3447",
                                     "s" : [ {
                                        "value" : [ "ConceptText","(" ]
                                     }, {
-                                       "r" : "3268",
+                                       "r" : "3436",
                                        "s" : [ {
-                                          "r" : "3270",
+                                          "r" : "3438",
                                           "s" : [ {
-                                             "r" : "3269",
+                                             "r" : "3437",
                                              "s" : [ {
                                                 "value" : [ "E" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "3270",
+                                             "r" : "3438",
                                              "s" : [ {
                                                 "value" : [ "reasonCode" ]
                                              } ]
                                           } ]
                                        }, {
-                                          "r" : "3275",
+                                          "r" : "3443",
                                           "value" : [ "[","0","]" ]
                                        } ]
                                     }, {
@@ -14217,16 +15001,16 @@
                               "s" : [ {
                                  "value" : [ "value",": " ]
                               }, {
-                                 "r" : "3282",
+                                 "r" : "3450",
                                  "s" : [ {
-                                    "r" : "3281",
+                                    "r" : "3449",
                                     "s" : [ {
                                        "value" : [ "E" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3282",
+                                    "r" : "3450",
                                     "s" : [ {
                                        "value" : [ "status" ]
                                     } ]
@@ -14238,41 +15022,41 @@
                               "s" : [ {
                                  "value" : [ "date",": " ]
                               }, {
-                                 "r" : "3307",
+                                 "r" : "3475",
                                  "s" : [ {
-                                    "r" : "3296",
+                                    "r" : "3464",
                                     "s" : [ {
-                                       "r" : "3291",
+                                       "r" : "3459",
                                        "s" : [ {
-                                          "r" : "3285",
+                                          "r" : "3453",
                                           "s" : [ {
                                              "value" : [ "Common" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3291",
+                                          "r" : "3459",
                                           "s" : [ {
                                              "value" : [ "DateTimeText","(" ]
                                           }, {
-                                             "r" : "3290",
+                                             "r" : "3458",
                                              "s" : [ {
-                                                "r" : "3286",
+                                                "r" : "3454",
                                                 "s" : [ {
                                                    "value" : [ "(" ]
                                                 }, {
-                                                   "r" : "3286",
+                                                   "r" : "3454",
                                                    "s" : [ {
-                                                      "r" : "3288",
+                                                      "r" : "3456",
                                                       "s" : [ {
-                                                         "r" : "3287",
+                                                         "r" : "3455",
                                                          "s" : [ {
                                                             "value" : [ "E" ]
                                                          } ]
                                                       }, {
                                                          "value" : [ "." ]
                                                       }, {
-                                                         "r" : "3288",
+                                                         "r" : "3456",
                                                          "s" : [ {
                                                             "value" : [ "period" ]
                                                          } ]
@@ -14280,7 +15064,7 @@
                                                    }, {
                                                       "value" : [ " as " ]
                                                    }, {
-                                                      "r" : "3289",
+                                                      "r" : "3457",
                                                       "s" : [ {
                                                          "value" : [ "FHIR",".","Period" ]
                                                       } ]
@@ -14291,7 +15075,7 @@
                                              }, {
                                                 "value" : [ "." ]
                                              }, {
-                                                "r" : "3290",
+                                                "r" : "3458",
                                                 "s" : [ {
                                                    "value" : [ "\"start\"" ]
                                                 } ]
@@ -14303,7 +15087,7 @@
                                     }, {
                                        "value" : [ " +\n      " ]
                                     }, {
-                                       "r" : "3293",
+                                       "r" : "3461",
                                        "s" : [ {
                                           "value" : [ "' to '" ]
                                        } ]
@@ -14311,37 +15095,37 @@
                                  }, {
                                     "value" : [ " +\n      " ]
                                  }, {
-                                    "r" : "3303",
+                                    "r" : "3471",
                                     "s" : [ {
-                                       "r" : "3297",
+                                       "r" : "3465",
                                        "s" : [ {
                                           "value" : [ "Common" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3303",
+                                       "r" : "3471",
                                        "s" : [ {
                                           "value" : [ "DateTimeText","(" ]
                                        }, {
-                                          "r" : "3302",
+                                          "r" : "3470",
                                           "s" : [ {
-                                             "r" : "3298",
+                                             "r" : "3466",
                                              "s" : [ {
                                                 "value" : [ "(" ]
                                              }, {
-                                                "r" : "3298",
+                                                "r" : "3466",
                                                 "s" : [ {
-                                                   "r" : "3300",
+                                                   "r" : "3468",
                                                    "s" : [ {
-                                                      "r" : "3299",
+                                                      "r" : "3467",
                                                       "s" : [ {
                                                          "value" : [ "E" ]
                                                       } ]
                                                    }, {
                                                       "value" : [ "." ]
                                                    }, {
-                                                      "r" : "3300",
+                                                      "r" : "3468",
                                                       "s" : [ {
                                                          "value" : [ "period" ]
                                                       } ]
@@ -14349,7 +15133,7 @@
                                                 }, {
                                                    "value" : [ " as " ]
                                                 }, {
-                                                   "r" : "3301",
+                                                   "r" : "3469",
                                                    "s" : [ {
                                                       "value" : [ "FHIR",".","Period" ]
                                                    } ]
@@ -14360,7 +15144,7 @@
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "3302",
+                                             "r" : "3470",
                                              "s" : [ {
                                                 "value" : [ "\"end\"" ]
                                              } ]
@@ -14377,25 +15161,25 @@
                               "s" : [ {
                                  "value" : [ "reference",": " ]
                               }, {
-                                 "r" : "3316",
+                                 "r" : "3484",
                                  "s" : [ {
-                                    "r" : "3309",
+                                    "r" : "3477",
                                     "s" : [ {
                                        "value" : [ "'Encounter/'" ]
                                     } ]
                                  }, {
                                     "value" : [ " + " ]
                                  }, {
-                                    "r" : "3311",
+                                    "r" : "3479",
                                     "s" : [ {
-                                       "r" : "3310",
+                                       "r" : "3478",
                                        "s" : [ {
                                           "value" : [ "E" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3311",
+                                       "r" : "3479",
                                        "s" : [ {
                                           "value" : [ "id" ]
                                        } ]
@@ -14411,40 +15195,40 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4699",
+               "localId" : "4885",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4700",
+                  "localId" : "4886",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4701",
+                     "localId" : "4887",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4702",
+                        "localId" : "4888",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4703",
+                     "localId" : "4889",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4704",
+                        "localId" : "4890",
                         "name" : "{http://hl7.org/fhir}EncounterStatus",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4705",
+                     "localId" : "4891",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4706",
+                        "localId" : "4892",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4707",
+                     "localId" : "4893",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4708",
+                        "localId" : "4894",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -14452,44 +15236,44 @@
                }
             },
             "expression" : {
-               "localId" : "3336",
+               "localId" : "3504",
                "locator" : "266:3-274:3",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3337",
+                  "localId" : "3505",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3338",
+                     "localId" : "3506",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3339",
+                        "localId" : "3507",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3340",
+                           "localId" : "3508",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3341",
+                        "localId" : "3509",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "3342",
+                           "localId" : "3510",
                            "name" : "{http://hl7.org/fhir}EncounterStatus",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3343",
+                        "localId" : "3511",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "3344",
+                           "localId" : "3512",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3345",
+                        "localId" : "3513",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "3346",
+                           "localId" : "3514",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -14497,28 +15281,28 @@
                   }
                },
                "source" : [ {
-                  "localId" : "3247",
+                  "localId" : "3415",
                   "locator" : "266:3-266:25",
                   "alias" : "E",
                   "resultTypeSpecifier" : {
-                     "localId" : "3263",
+                     "localId" : "3431",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3264",
+                        "localId" : "3432",
                         "name" : "{http://hl7.org/fhir}Encounter",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3258",
+                     "localId" : "3426",
                      "locator" : "266:3-266:23",
                      "name" : "PertinentEncounters",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3261",
+                        "localId" : "3429",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3262",
+                           "localId" : "3430",
                            "name" : "{http://hl7.org/fhir}Encounter",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -14528,43 +15312,43 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "3265",
+                  "localId" : "3433",
                   "locator" : "267:3-274:3",
                   "resultTypeSpecifier" : {
-                     "localId" : "3326",
+                     "localId" : "3494",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3327",
+                        "localId" : "3495",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3328",
+                           "localId" : "3496",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3329",
+                              "localId" : "3497",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3330",
+                           "localId" : "3498",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "3331",
+                              "localId" : "3499",
                               "name" : "{http://hl7.org/fhir}EncounterStatus",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3332",
+                           "localId" : "3500",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "3333",
+                              "localId" : "3501",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3334",
+                           "localId" : "3502",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "3335",
+                              "localId" : "3503",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -14572,41 +15356,41 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3266",
+                     "localId" : "3434",
                      "locator" : "267:10-274:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "3317",
+                        "localId" : "3485",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3318",
+                           "localId" : "3486",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3319",
+                              "localId" : "3487",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3320",
+                           "localId" : "3488",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "3321",
+                              "localId" : "3489",
                               "name" : "{http://hl7.org/fhir}EncounterStatus",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3322",
+                           "localId" : "3490",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "3323",
+                              "localId" : "3491",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3324",
+                           "localId" : "3492",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "3325",
+                              "localId" : "3493",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -14615,52 +15399,52 @@
                      "element" : [ {
                         "name" : "name",
                         "value" : {
-                           "localId" : "3279",
+                           "localId" : "3447",
                            "locator" : "268:11-268:45",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ConceptText",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "3280",
+                              "localId" : "3448",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3268",
+                              "localId" : "3436",
                               "locator" : "268:30-268:44",
                               "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "Indexer",
                               "signature" : [ {
-                                 "localId" : "3276",
+                                 "localId" : "3444",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3277",
+                                    "localId" : "3445",
                                     "name" : "{http://hl7.org/fhir}CodeableConcept",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3278",
+                                 "localId" : "3446",
                                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3270",
+                                 "localId" : "3438",
                                  "locator" : "268:30-268:41",
                                  "path" : "reasonCode",
                                  "scope" : "E",
                                  "type" : "Property",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3273",
+                                    "localId" : "3441",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3274",
+                                       "localId" : "3442",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "3275",
+                                 "localId" : "3443",
                                  "locator" : "268:43",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -14672,7 +15456,7 @@
                      }, {
                         "name" : "value",
                         "value" : {
-                           "localId" : "3282",
+                           "localId" : "3450",
                            "locator" : "269:12-269:19",
                            "resultTypeName" : "{http://hl7.org/fhir}EncounterStatus",
                            "path" : "status",
@@ -14682,44 +15466,44 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "localId" : "3307",
+                           "localId" : "3475",
                            "locator" : "270:11-272:58",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "Concatenate",
                            "signature" : [ ],
                            "operand" : [ {
-                              "localId" : "3296",
+                              "localId" : "3464",
                               "locator" : "270:11-271:12",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "Concatenate",
                               "signature" : [ ],
                               "operand" : [ {
-                                 "localId" : "3291",
+                                 "localId" : "3459",
                                  "locator" : "270:11-270:64",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                  "name" : "DateTimeText",
                                  "libraryName" : "Common",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "3292",
+                                    "localId" : "3460",
                                     "name" : "{http://hl7.org/fhir}dateTime",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3290",
+                                    "localId" : "3458",
                                     "locator" : "270:31-270:63",
                                     "resultTypeName" : "{http://hl7.org/fhir}dateTime",
                                     "path" : "start",
                                     "type" : "Property",
                                     "source" : {
-                                       "localId" : "3286",
+                                       "localId" : "3454",
                                        "locator" : "270:31-270:55",
                                        "resultTypeName" : "{http://hl7.org/fhir}Period",
                                        "strict" : false,
                                        "type" : "As",
                                        "signature" : [ ],
                                        "operand" : {
-                                          "localId" : "3288",
+                                          "localId" : "3456",
                                           "locator" : "270:32-270:39",
                                           "resultTypeName" : "{http://hl7.org/fhir}Period",
                                           "path" : "period",
@@ -14727,7 +15511,7 @@
                                           "type" : "Property"
                                        },
                                        "asTypeSpecifier" : {
-                                          "localId" : "3289",
+                                          "localId" : "3457",
                                           "locator" : "270:44-270:54",
                                           "resultTypeName" : "{http://hl7.org/fhir}Period",
                                           "name" : "{http://hl7.org/fhir}Period",
@@ -14736,7 +15520,7 @@
                                     }
                                  } ]
                               }, {
-                                 "localId" : "3293",
+                                 "localId" : "3461",
                                  "locator" : "271:7-271:12",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -14744,32 +15528,32 @@
                                  "type" : "Literal"
                               } ]
                            }, {
-                              "localId" : "3303",
+                              "localId" : "3471",
                               "locator" : "272:7-272:58",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "name" : "DateTimeText",
                               "libraryName" : "Common",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3304",
+                                 "localId" : "3472",
                                  "name" : "{http://hl7.org/fhir}dateTime",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3302",
+                                 "localId" : "3470",
                                  "locator" : "272:27-272:57",
                                  "resultTypeName" : "{http://hl7.org/fhir}dateTime",
                                  "path" : "end",
                                  "type" : "Property",
                                  "source" : {
-                                    "localId" : "3298",
+                                    "localId" : "3466",
                                     "locator" : "272:27-272:51",
                                     "resultTypeName" : "{http://hl7.org/fhir}Period",
                                     "strict" : false,
                                     "type" : "As",
                                     "signature" : [ ],
                                     "operand" : {
-                                       "localId" : "3300",
+                                       "localId" : "3468",
                                        "locator" : "272:28-272:35",
                                        "resultTypeName" : "{http://hl7.org/fhir}Period",
                                        "path" : "period",
@@ -14777,7 +15561,7 @@
                                        "type" : "Property"
                                     },
                                     "asTypeSpecifier" : {
-                                       "localId" : "3301",
+                                       "localId" : "3469",
                                        "locator" : "272:40-272:50",
                                        "resultTypeName" : "{http://hl7.org/fhir}Period",
                                        "name" : "{http://hl7.org/fhir}Period",
@@ -14790,30 +15574,30 @@
                      }, {
                         "name" : "reference",
                         "value" : {
-                           "localId" : "3316",
+                           "localId" : "3484",
                            "locator" : "273:16-273:34",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "Concatenate",
                            "signature" : [ ],
                            "operand" : [ {
-                              "localId" : "3309",
+                              "localId" : "3477",
                               "locator" : "273:16-273:27",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "Encounter/",
                               "type" : "Literal"
                            }, {
-                              "localId" : "3312",
+                              "localId" : "3480",
                               "name" : "ToString",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3313",
+                                 "localId" : "3481",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3311",
+                                 "localId" : "3479",
                                  "locator" : "273:31-273:34",
                                  "resultTypeName" : "{http://hl7.org/fhir}id",
                                  "path" : "id",
@@ -14827,7 +15611,7 @@
                }
             }
          }, {
-            "localId" : "3372",
+            "localId" : "3540",
             "locator" : "279:3-280:40",
             "name" : "PertinentEpisodesOfCare",
             "context" : "Patient",
@@ -14835,20 +15619,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3372",
+                  "r" : "3540",
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// PERTINENT EPISODES OF CARE\n//------------------------------------------------------------------------------\n  ","define ","PertinentEpisodesOfCare",":\n    " ]
                   }, {
-                     "r" : "3374",
+                     "r" : "3542",
                      "s" : [ {
-                        "r" : "3373",
+                        "r" : "3541",
                         "s" : [ {
                            "value" : [ "DataElements" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "3374",
+                        "r" : "3542",
                         "s" : [ {
                            "value" : [ "PregnancyEpisodesOfCare" ]
                         } ]
@@ -14857,33 +15641,33 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4709",
+               "localId" : "4895",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4710",
+                  "localId" : "4896",
                   "name" : "{http://hl7.org/fhir}EpisodeOfCare",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "expression" : {
-               "localId" : "3374",
+               "localId" : "3542",
                "locator" : "280:5-280:40",
                "name" : "PregnancyEpisodesOfCare",
                "libraryName" : "DataElements",
                "type" : "ExpressionRef",
                "resultTypeSpecifier" : {
-                  "localId" : "3377",
+                  "localId" : "3545",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3378",
+                     "localId" : "3546",
                      "name" : "{http://hl7.org/fhir}EpisodeOfCare",
                      "type" : "NamedTypeSpecifier"
                   }
                }
             }
          }, {
-            "localId" : "3425",
-            "locator" : "357:1-361:29",
+            "localId" : "3593",
+            "locator" : "366:1-370:29",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
             "name" : "displayStartDate",
             "context" : "Patient",
@@ -14892,19 +15676,19 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3425",
+                  "r" : "3593",
                   "s" : [ {
                      "value" : [ "","define function displayStartDate(startDate String):\n  " ]
                   }, {
-                     "r" : "5138",
+                     "r" : "5426",
                      "s" : [ {
-                        "r" : "5138",
+                        "r" : "5426",
                         "s" : [ {
                            "value" : [ "if " ]
                         }, {
-                           "r" : "5142",
+                           "r" : "5430",
                            "s" : [ {
-                              "r" : "5139",
+                              "r" : "5427",
                               "s" : [ {
                                  "value" : [ "startDate" ]
                               } ]
@@ -14914,14 +15698,14 @@
                         }, {
                            "value" : [ " then\n    " ]
                         }, {
-                           "r" : "5144",
+                           "r" : "5432",
                            "s" : [ {
                               "value" : [ "startDate" ]
                            } ]
                         }, {
                            "value" : [ "\n  else\n    " ]
                         }, {
-                           "r" : "5145",
+                           "r" : "5433",
                            "s" : [ {
                               "value" : [ "'no start date available'" ]
                            } ]
@@ -14931,33 +15715,33 @@
                }
             } ],
             "expression" : {
-               "localId" : "5138",
-               "locator" : "358:3-361:29",
+               "localId" : "5426",
+               "locator" : "367:3-370:29",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                "type" : "If",
                "condition" : {
-                  "localId" : "5142",
-                  "locator" : "358:6-358:26",
+                  "localId" : "5430",
+                  "locator" : "367:6-367:26",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Not",
                   "signature" : [ {
-                     "localId" : "5143",
+                     "localId" : "5431",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : {
-                     "localId" : "5140",
-                     "locator" : "358:6-358:26",
+                     "localId" : "5428",
+                     "locator" : "367:6-367:26",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "IsNull",
                      "signature" : [ {
-                        "localId" : "5141",
+                        "localId" : "5429",
                         "name" : "{urn:hl7-org:elm-types:r1}Any",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : {
-                        "localId" : "5139",
-                        "locator" : "358:6-358:14",
+                        "localId" : "5427",
+                        "locator" : "367:6-367:14",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "name" : "startDate",
                         "type" : "OperandRef"
@@ -14965,15 +15749,15 @@
                   }
                },
                "then" : {
-                  "localId" : "5144",
-                  "locator" : "359:5-359:13",
+                  "localId" : "5432",
+                  "locator" : "368:5-368:13",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "name" : "startDate",
                   "type" : "OperandRef"
                },
                "else" : {
-                  "localId" : "5145",
-                  "locator" : "361:5-361:29",
+                  "localId" : "5433",
+                  "locator" : "370:5-370:29",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "no start date available",
@@ -14981,19 +15765,19 @@
                }
             },
             "operand" : [ {
-               "localId" : "3427",
+               "localId" : "3595",
                "name" : "startDate",
                "operandTypeSpecifier" : {
-                  "localId" : "3426",
-                  "locator" : "357:44-357:49",
+                  "localId" : "3594",
+                  "locator" : "366:44-366:49",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "3458",
-            "locator" : "363:1-367:27",
+            "localId" : "3626",
+            "locator" : "372:1-376:27",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
             "name" : "displayEndDate",
             "context" : "Patient",
@@ -15002,19 +15786,19 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3458",
+                  "r" : "3626",
                   "s" : [ {
                      "value" : [ "","define function displayEndDate(endDate String):\n  " ]
                   }, {
-                     "r" : "5146",
+                     "r" : "5434",
                      "s" : [ {
-                        "r" : "5146",
+                        "r" : "5434",
                         "s" : [ {
                            "value" : [ "if " ]
                         }, {
-                           "r" : "5150",
+                           "r" : "5438",
                            "s" : [ {
-                              "r" : "5147",
+                              "r" : "5435",
                               "s" : [ {
                                  "value" : [ "endDate" ]
                               } ]
@@ -15024,14 +15808,14 @@
                         }, {
                            "value" : [ " then\n    " ]
                         }, {
-                           "r" : "5152",
+                           "r" : "5440",
                            "s" : [ {
                               "value" : [ "endDate" ]
                            } ]
                         }, {
                            "value" : [ "\n  else\n    " ]
                         }, {
-                           "r" : "5153",
+                           "r" : "5441",
                            "s" : [ {
                               "value" : [ "'no end date available'" ]
                            } ]
@@ -15041,33 +15825,33 @@
                }
             } ],
             "expression" : {
-               "localId" : "5146",
-               "locator" : "364:3-367:27",
+               "localId" : "5434",
+               "locator" : "373:3-376:27",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                "type" : "If",
                "condition" : {
-                  "localId" : "5150",
-                  "locator" : "364:6-364:24",
+                  "localId" : "5438",
+                  "locator" : "373:6-373:24",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Not",
                   "signature" : [ {
-                     "localId" : "5151",
+                     "localId" : "5439",
                      "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : {
-                     "localId" : "5148",
-                     "locator" : "364:6-364:24",
+                     "localId" : "5436",
+                     "locator" : "373:6-373:24",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "IsNull",
                      "signature" : [ {
-                        "localId" : "5149",
+                        "localId" : "5437",
                         "name" : "{urn:hl7-org:elm-types:r1}Any",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : {
-                        "localId" : "5147",
-                        "locator" : "364:6-364:12",
+                        "localId" : "5435",
+                        "locator" : "373:6-373:12",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "name" : "endDate",
                         "type" : "OperandRef"
@@ -15075,15 +15859,15 @@
                   }
                },
                "then" : {
-                  "localId" : "5152",
-                  "locator" : "365:5-365:11",
+                  "localId" : "5440",
+                  "locator" : "374:5-374:11",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "name" : "endDate",
                   "type" : "OperandRef"
                },
                "else" : {
-                  "localId" : "5153",
-                  "locator" : "367:5-367:27",
+                  "localId" : "5441",
+                  "locator" : "376:5-376:27",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "no end date available",
@@ -15091,18 +15875,18 @@
                }
             },
             "operand" : [ {
-               "localId" : "3460",
+               "localId" : "3628",
                "name" : "endDate",
                "operandTypeSpecifier" : {
-                  "localId" : "3459",
-                  "locator" : "363:40-363:45",
+                  "localId" : "3627",
+                  "locator" : "372:40-372:45",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "3369",
+            "localId" : "3537",
             "locator" : "282:1-294:31",
             "name" : "PertinentEpisodesOfCareSummary",
             "context" : "Patient",
@@ -15110,20 +15894,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3369",
+                  "r" : "3537",
                   "s" : [ {
                      "value" : [ "","define ","PertinentEpisodesOfCareSummary",":\n  " ]
                   }, {
-                     "r" : "3523",
+                     "r" : "3691",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3370",
+                           "r" : "3538",
                            "s" : [ {
-                              "r" : "3381",
+                              "r" : "3549",
                               "s" : [ {
                                  "value" : [ "(" ]
                               }, {
-                                 "r" : "3381",
+                                 "r" : "3549",
                                  "s" : [ {
                                     "value" : [ "PertinentEpisodesOfCare" ]
                                  } ]
@@ -15137,48 +15921,48 @@
                      }, {
                         "value" : [ "\n  " ]
                      }, {
-                        "r" : "3388",
+                        "r" : "3556",
                         "s" : [ {
                            "value" : [ "return " ]
                         }, {
-                           "r" : "3389",
+                           "r" : "3557",
                            "s" : [ {
                               "value" : [ "{\n    " ]
                            }, {
                               "s" : [ {
                                  "value" : [ "name",": " ]
                               }, {
-                                 "r" : "3402",
+                                 "r" : "3570",
                                  "s" : [ {
-                                    "r" : "3390",
+                                    "r" : "3558",
                                     "s" : [ {
                                        "value" : [ "Common" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3402",
+                                    "r" : "3570",
                                     "s" : [ {
                                        "value" : [ "ConceptText","(" ]
                                     }, {
-                                       "r" : "3391",
+                                       "r" : "3559",
                                        "s" : [ {
-                                          "r" : "3393",
+                                          "r" : "3561",
                                           "s" : [ {
-                                             "r" : "3392",
+                                             "r" : "3560",
                                              "s" : [ {
                                                 "value" : [ "E" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "3393",
+                                             "r" : "3561",
                                              "s" : [ {
                                                 "value" : [ "type" ]
                                              } ]
                                           } ]
                                        }, {
-                                          "r" : "3398",
+                                          "r" : "3566",
                                           "value" : [ "[","0","]" ]
                                        } ]
                                     }, {
@@ -15192,18 +15976,18 @@
                               "s" : [ {
                                  "value" : [ "value",": " ]
                               }, {
-                                 "r" : "3406",
+                                 "r" : "3574",
                                  "s" : [ {
-                                    "r" : "3405",
+                                    "r" : "3573",
                                     "s" : [ {
-                                       "r" : "3404",
+                                       "r" : "3572",
                                        "s" : [ {
                                           "value" : [ "E" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3405",
+                                       "r" : "3573",
                                        "s" : [ {
                                           "value" : [ "status" ]
                                        } ]
@@ -15211,7 +15995,7 @@
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3406",
+                                    "r" : "3574",
                                     "s" : [ {
                                        "value" : [ "value" ]
                                     } ]
@@ -15223,39 +16007,39 @@
                               "s" : [ {
                                  "value" : [ "date",":\n      " ]
                               }, {
-                                 "r" : "3473",
+                                 "r" : "3641",
                                  "s" : [ {
-                                    "r" : "3441",
+                                    "r" : "3609",
                                     "s" : [ {
-                                       "r" : "3428",
+                                       "r" : "3596",
                                        "s" : [ {
                                           "value" : [ "displayStartDate","(" ]
                                        }, {
-                                          "r" : "3424",
+                                          "r" : "3592",
                                           "s" : [ {
-                                             "r" : "3412",
+                                             "r" : "3580",
                                              "s" : [ {
-                                                "r" : "3409",
+                                                "r" : "3577",
                                                 "s" : [ {
                                                    "value" : [ "Common" ]
                                                 } ]
                                              }, {
                                                 "value" : [ "." ]
                                              }, {
-                                                "r" : "3412",
+                                                "r" : "3580",
                                                 "s" : [ {
                                                    "value" : [ "PeriodObject","(" ]
                                                 }, {
-                                                   "r" : "3411",
+                                                   "r" : "3579",
                                                    "s" : [ {
-                                                      "r" : "3410",
+                                                      "r" : "3578",
                                                       "s" : [ {
                                                          "value" : [ "E" ]
                                                       } ]
                                                    }, {
                                                       "value" : [ "." ]
                                                    }, {
-                                                      "r" : "3411",
+                                                      "r" : "3579",
                                                       "s" : [ {
                                                          "value" : [ "period" ]
                                                       } ]
@@ -15267,7 +16051,7 @@
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "3424",
+                                             "r" : "3592",
                                              "s" : [ {
                                                 "value" : [ "\"Start\"" ]
                                              } ]
@@ -15278,7 +16062,7 @@
                                     }, {
                                        "value" : [ " +\n      " ]
                                     }, {
-                                       "r" : "3438",
+                                       "r" : "3606",
                                        "s" : [ {
                                           "value" : [ "' to '" ]
                                        } ]
@@ -15286,35 +16070,35 @@
                                  }, {
                                     "value" : [ " +\n      " ]
                                  }, {
-                                    "r" : "3461",
+                                    "r" : "3629",
                                     "s" : [ {
                                        "value" : [ "displayEndDate","(" ]
                                     }, {
-                                       "r" : "3457",
+                                       "r" : "3625",
                                        "s" : [ {
-                                          "r" : "3445",
+                                          "r" : "3613",
                                           "s" : [ {
-                                             "r" : "3442",
+                                             "r" : "3610",
                                              "s" : [ {
                                                 "value" : [ "Common" ]
                                              } ]
                                           }, {
                                              "value" : [ "." ]
                                           }, {
-                                             "r" : "3445",
+                                             "r" : "3613",
                                              "s" : [ {
                                                 "value" : [ "PeriodObject","(" ]
                                              }, {
-                                                "r" : "3444",
+                                                "r" : "3612",
                                                 "s" : [ {
-                                                   "r" : "3443",
+                                                   "r" : "3611",
                                                    "s" : [ {
                                                       "value" : [ "E" ]
                                                    } ]
                                                 }, {
                                                    "value" : [ "." ]
                                                 }, {
-                                                   "r" : "3444",
+                                                   "r" : "3612",
                                                    "s" : [ {
                                                       "value" : [ "period" ]
                                                    } ]
@@ -15326,7 +16110,7 @@
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3457",
+                                          "r" : "3625",
                                           "s" : [ {
                                              "value" : [ "\"End\"" ]
                                           } ]
@@ -15342,25 +16126,25 @@
                               "s" : [ {
                                  "value" : [ "reference",": " ]
                               }, {
-                                 "r" : "3482",
+                                 "r" : "3650",
                                  "s" : [ {
-                                    "r" : "3475",
+                                    "r" : "3643",
                                     "s" : [ {
                                        "value" : [ "'EpisodeOfCare/'" ]
                                     } ]
                                  }, {
                                     "value" : [ " + " ]
                                  }, {
-                                    "r" : "3477",
+                                    "r" : "3645",
                                     "s" : [ {
-                                       "r" : "3476",
+                                       "r" : "3644",
                                        "s" : [ {
                                           "value" : [ "E" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3477",
+                                       "r" : "3645",
                                        "s" : [ {
                                           "value" : [ "id" ]
                                        } ]
@@ -15373,11 +16157,11 @@
                               "s" : [ {
                                  "value" : [ "edited",": " ]
                               }, {
-                                 "r" : "3484",
+                                 "r" : "3652",
                                  "s" : [ {
                                     "value" : [ "HasBeenLocallyEdited","(" ]
                                  }, {
-                                    "r" : "3483",
+                                    "r" : "3651",
                                     "s" : [ {
                                        "value" : [ "E" ]
                                     } ]
@@ -15392,26 +16176,26 @@
                      }, {
                         "value" : [ "\n  " ]
                      }, {
-                        "r" : "3517",
+                        "r" : "3685",
                         "s" : [ {
                            "value" : [ "sort by " ]
                         }, {
-                           "r" : "3516",
+                           "r" : "3684",
                            "s" : [ {
-                              "r" : "3513",
+                              "r" : "3681",
                               "s" : [ {
                                  "value" : [ "(" ]
                               }, {
-                                 "r" : "3513",
+                                 "r" : "3681",
                                  "s" : [ {
-                                    "r" : "3514",
+                                    "r" : "3682",
                                     "s" : [ {
                                        "value" : [ "date" ]
                                     } ]
                                  }, {
                                     "value" : [ " as " ]
                                  }, {
-                                    "r" : "3515",
+                                    "r" : "3683",
                                     "s" : [ {
                                        "value" : [ "String" ]
                                     } ]
@@ -15428,51 +16212,51 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4711",
+               "localId" : "4897",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4712",
+                  "localId" : "4898",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4713",
+                     "localId" : "4899",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4714",
+                        "localId" : "4900",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4715",
+                     "localId" : "4901",
                      "name" : "value",
                      "elementType" : {
-                        "localId" : "4716",
+                        "localId" : "4902",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4717",
+                     "localId" : "4903",
                      "name" : "date",
                      "elementType" : {
-                        "localId" : "4718",
+                        "localId" : "4904",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4719",
+                     "localId" : "4905",
                      "name" : "reference",
                      "elementType" : {
-                        "localId" : "4720",
+                        "localId" : "4906",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4721",
+                     "localId" : "4907",
                      "name" : "edited",
                      "elementType" : {
-                        "localId" : "4722",
+                        "localId" : "4908",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "4723",
+                           "localId" : "4909",
                            "name" : "{http://hl7.org/fhir}Extension",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -15481,55 +16265,55 @@
                }
             },
             "expression" : {
-               "localId" : "3523",
+               "localId" : "3691",
                "locator" : "283:3-294:31",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3524",
+                  "localId" : "3692",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3525",
+                     "localId" : "3693",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3526",
+                        "localId" : "3694",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3527",
+                           "localId" : "3695",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3528",
+                        "localId" : "3696",
                         "name" : "value",
                         "elementType" : {
-                           "localId" : "3529",
+                           "localId" : "3697",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3530",
+                        "localId" : "3698",
                         "name" : "date",
                         "elementType" : {
-                           "localId" : "3531",
+                           "localId" : "3699",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3532",
+                        "localId" : "3700",
                         "name" : "reference",
                         "elementType" : {
-                           "localId" : "3533",
+                           "localId" : "3701",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3534",
+                        "localId" : "3702",
                         "name" : "edited",
                         "elementType" : {
-                           "localId" : "3535",
+                           "localId" : "3703",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "3536",
+                              "localId" : "3704",
                               "name" : "{http://hl7.org/fhir}Extension",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -15538,28 +16322,28 @@
                   }
                },
                "source" : [ {
-                  "localId" : "3370",
+                  "localId" : "3538",
                   "locator" : "283:3-283:29",
                   "alias" : "E",
                   "resultTypeSpecifier" : {
-                     "localId" : "3386",
+                     "localId" : "3554",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3387",
+                        "localId" : "3555",
                         "name" : "{http://hl7.org/fhir}EpisodeOfCare",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3381",
+                     "localId" : "3549",
                      "locator" : "283:3-283:27",
                      "name" : "PertinentEpisodesOfCare",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3384",
+                        "localId" : "3552",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3385",
+                           "localId" : "3553",
                            "name" : "{http://hl7.org/fhir}EpisodeOfCare",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -15569,54 +16353,54 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "3388",
+                  "localId" : "3556",
                   "locator" : "284:3-293:3",
                   "resultTypeSpecifier" : {
-                     "localId" : "3500",
+                     "localId" : "3668",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3501",
+                        "localId" : "3669",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3502",
+                           "localId" : "3670",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3503",
+                              "localId" : "3671",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3504",
+                           "localId" : "3672",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "3505",
+                              "localId" : "3673",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3506",
+                           "localId" : "3674",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "3507",
+                              "localId" : "3675",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3508",
+                           "localId" : "3676",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "3509",
+                              "localId" : "3677",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3510",
+                           "localId" : "3678",
                            "name" : "edited",
                            "elementType" : {
-                              "localId" : "3511",
+                              "localId" : "3679",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3512",
+                                 "localId" : "3680",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -15625,52 +16409,52 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3389",
+                     "localId" : "3557",
                      "locator" : "284:10-293:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "3488",
+                        "localId" : "3656",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3489",
+                           "localId" : "3657",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3490",
+                              "localId" : "3658",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3491",
+                           "localId" : "3659",
                            "name" : "value",
                            "elementType" : {
-                              "localId" : "3492",
+                              "localId" : "3660",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3493",
+                           "localId" : "3661",
                            "name" : "date",
                            "elementType" : {
-                              "localId" : "3494",
+                              "localId" : "3662",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3495",
+                           "localId" : "3663",
                            "name" : "reference",
                            "elementType" : {
-                              "localId" : "3496",
+                              "localId" : "3664",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3497",
+                           "localId" : "3665",
                            "name" : "edited",
                            "elementType" : {
-                              "localId" : "3498",
+                              "localId" : "3666",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3499",
+                                 "localId" : "3667",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -15680,52 +16464,52 @@
                      "element" : [ {
                         "name" : "name",
                         "value" : {
-                           "localId" : "3402",
+                           "localId" : "3570",
                            "locator" : "285:11-285:39",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ConceptText",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "3403",
+                              "localId" : "3571",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3391",
+                              "localId" : "3559",
                               "locator" : "285:30-285:38",
                               "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "Indexer",
                               "signature" : [ {
-                                 "localId" : "3399",
+                                 "localId" : "3567",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "3400",
+                                    "localId" : "3568",
                                     "name" : "{http://hl7.org/fhir}CodeableConcept",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "3401",
+                                 "localId" : "3569",
                                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3393",
+                                 "localId" : "3561",
                                  "locator" : "285:30-285:35",
                                  "path" : "type",
                                  "scope" : "E",
                                  "type" : "Property",
                                  "resultTypeSpecifier" : {
-                                    "localId" : "3396",
+                                    "localId" : "3564",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "3397",
+                                       "localId" : "3565",
                                        "name" : "{http://hl7.org/fhir}CodeableConcept",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "3398",
+                                 "localId" : "3566",
                                  "locator" : "285:37",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -15737,13 +16521,13 @@
                      }, {
                         "name" : "value",
                         "value" : {
-                           "localId" : "3406",
+                           "localId" : "3574",
                            "locator" : "286:12-286:25",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "path" : "value",
                            "type" : "Property",
                            "source" : {
-                              "localId" : "3405",
+                              "localId" : "3573",
                               "locator" : "286:12-286:19",
                               "resultTypeName" : "{http://hl7.org/fhir}EpisodeOfCareStatus",
                               "path" : "status",
@@ -15754,68 +16538,68 @@
                      }, {
                         "name" : "date",
                         "value" : {
-                           "localId" : "3473",
+                           "localId" : "3641",
                            "locator" : "288:7-290:57",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "Concatenate",
                            "signature" : [ ],
                            "operand" : [ {
-                              "localId" : "3441",
+                              "localId" : "3609",
                               "locator" : "288:7-289:12",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "Concatenate",
                               "signature" : [ ],
                               "operand" : [ {
-                                 "localId" : "3428",
+                                 "localId" : "3596",
                                  "locator" : "288:7-288:61",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                  "name" : "displayStartDate",
                                  "type" : "FunctionRef",
                                  "signature" : [ {
-                                    "localId" : "3429",
+                                    "localId" : "3597",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  } ],
                                  "operand" : [ {
-                                    "localId" : "3424",
+                                    "localId" : "3592",
                                     "locator" : "288:24-288:60",
                                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                     "path" : "Start",
                                     "type" : "Property",
                                     "source" : {
-                                       "localId" : "3412",
+                                       "localId" : "3580",
                                        "locator" : "288:24-288:52",
                                        "name" : "PeriodObject",
                                        "libraryName" : "Common",
                                        "type" : "FunctionRef",
                                        "resultTypeSpecifier" : {
-                                          "localId" : "3419",
+                                          "localId" : "3587",
                                           "type" : "TupleTypeSpecifier",
                                           "element" : [ {
-                                             "localId" : "3420",
+                                             "localId" : "3588",
                                              "name" : "Start",
                                              "elementType" : {
-                                                "localId" : "3421",
+                                                "localId" : "3589",
                                                 "name" : "{urn:hl7-org:elm-types:r1}String",
                                                 "type" : "NamedTypeSpecifier"
                                              }
                                           }, {
-                                             "localId" : "3422",
+                                             "localId" : "3590",
                                              "name" : "End",
                                              "elementType" : {
-                                                "localId" : "3423",
+                                                "localId" : "3591",
                                                 "name" : "{urn:hl7-org:elm-types:r1}String",
                                                 "type" : "NamedTypeSpecifier"
                                              }
                                           } ]
                                        },
                                        "signature" : [ {
-                                          "localId" : "3413",
+                                          "localId" : "3581",
                                           "name" : "{http://hl7.org/fhir}Period",
                                           "type" : "NamedTypeSpecifier"
                                        } ],
                                        "operand" : [ {
-                                          "localId" : "3411",
+                                          "localId" : "3579",
                                           "locator" : "288:44-288:51",
                                           "resultTypeName" : "{http://hl7.org/fhir}Period",
                                           "path" : "period",
@@ -15825,7 +16609,7 @@
                                     }
                                  } ]
                               }, {
-                                 "localId" : "3438",
+                                 "localId" : "3606",
                                  "locator" : "289:7-289:12",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -15833,56 +16617,56 @@
                                  "type" : "Literal"
                               } ]
                            }, {
-                              "localId" : "3461",
+                              "localId" : "3629",
                               "locator" : "290:7-290:57",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "name" : "displayEndDate",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3462",
+                                 "localId" : "3630",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3457",
+                                 "localId" : "3625",
                                  "locator" : "290:22-290:56",
                                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                                  "path" : "End",
                                  "type" : "Property",
                                  "source" : {
-                                    "localId" : "3445",
+                                    "localId" : "3613",
                                     "locator" : "290:22-290:50",
                                     "name" : "PeriodObject",
                                     "libraryName" : "Common",
                                     "type" : "FunctionRef",
                                     "resultTypeSpecifier" : {
-                                       "localId" : "3452",
+                                       "localId" : "3620",
                                        "type" : "TupleTypeSpecifier",
                                        "element" : [ {
-                                          "localId" : "3453",
+                                          "localId" : "3621",
                                           "name" : "Start",
                                           "elementType" : {
-                                             "localId" : "3454",
+                                             "localId" : "3622",
                                              "name" : "{urn:hl7-org:elm-types:r1}String",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        }, {
-                                          "localId" : "3455",
+                                          "localId" : "3623",
                                           "name" : "End",
                                           "elementType" : {
-                                             "localId" : "3456",
+                                             "localId" : "3624",
                                              "name" : "{urn:hl7-org:elm-types:r1}String",
                                              "type" : "NamedTypeSpecifier"
                                           }
                                        } ]
                                     },
                                     "signature" : [ {
-                                       "localId" : "3446",
+                                       "localId" : "3614",
                                        "name" : "{http://hl7.org/fhir}Period",
                                        "type" : "NamedTypeSpecifier"
                                     } ],
                                     "operand" : [ {
-                                       "localId" : "3444",
+                                       "localId" : "3612",
                                        "locator" : "290:42-290:49",
                                        "resultTypeName" : "{http://hl7.org/fhir}Period",
                                        "path" : "period",
@@ -15896,30 +16680,30 @@
                      }, {
                         "name" : "reference",
                         "value" : {
-                           "localId" : "3482",
+                           "localId" : "3650",
                            "locator" : "291:16-291:38",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "Concatenate",
                            "signature" : [ ],
                            "operand" : [ {
-                              "localId" : "3475",
+                              "localId" : "3643",
                               "locator" : "291:16-291:31",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                               "valueType" : "{urn:hl7-org:elm-types:r1}String",
                               "value" : "EpisodeOfCare/",
                               "type" : "Literal"
                            }, {
-                              "localId" : "3478",
+                              "localId" : "3646",
                               "name" : "ToString",
                               "libraryName" : "FHIRHelpers",
                               "type" : "FunctionRef",
                               "signature" : [ {
-                                 "localId" : "3479",
+                                 "localId" : "3647",
                                  "name" : "{http://hl7.org/fhir}string",
                                  "type" : "NamedTypeSpecifier"
                               } ],
                               "operand" : [ {
-                                 "localId" : "3477",
+                                 "localId" : "3645",
                                  "locator" : "291:35-291:38",
                                  "resultTypeName" : "{http://hl7.org/fhir}id",
                                  "path" : "id",
@@ -15931,26 +16715,26 @@
                      }, {
                         "name" : "edited",
                         "value" : {
-                           "localId" : "3484",
+                           "localId" : "3652",
                            "locator" : "292:13-292:35",
                            "name" : "HasBeenLocallyEdited",
                            "type" : "FunctionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3486",
+                              "localId" : "3654",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3487",
+                                 "localId" : "3655",
                                  "name" : "{http://hl7.org/fhir}Extension",
                                  "type" : "NamedTypeSpecifier"
                               }
                            },
                            "signature" : [ {
-                              "localId" : "3485",
+                              "localId" : "3653",
                               "name" : "{http://hl7.org/fhir}DomainResource",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3483",
+                              "localId" : "3651",
                               "locator" : "292:34",
                               "resultTypeName" : "{http://hl7.org/fhir}EpisodeOfCare",
                               "name" : "E",
@@ -15961,30 +16745,30 @@
                   }
                },
                "sort" : {
-                  "localId" : "3517",
+                  "localId" : "3685",
                   "locator" : "294:3-294:31",
                   "by" : [ {
-                     "localId" : "3516",
+                     "localId" : "3684",
                      "locator" : "294:11-294:31",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "direction" : "desc",
                      "type" : "ByExpression",
                      "expression" : {
-                        "localId" : "3513",
+                        "localId" : "3681",
                         "locator" : "294:11-294:26",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "strict" : false,
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "3514",
+                           "localId" : "3682",
                            "locator" : "294:12-294:15",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "date",
                            "type" : "IdentifierRef"
                         },
                         "asTypeSpecifier" : {
-                           "localId" : "3515",
+                           "localId" : "3683",
                            "locator" : "294:20-294:25",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
@@ -15995,7 +16779,7 @@
                }
             }
          }, {
-            "localId" : "3567",
+            "localId" : "3735",
             "locator" : "301:1-310:3",
             "name" : "DueOrOverdueScreeningSummary",
             "context" : "Patient",
@@ -16003,29 +16787,29 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3567",
+                  "r" : "3735",
                   "s" : [ {
                      "value" : [ "//------------------------------------------------------------------------------\n// PERTINENT REQUESTS\n//------------------------------------------------------------------------------  \n\n","define ","DueOrOverdueScreeningSummary",":\n  " ]
                   }, {
-                     "r" : "3767",
+                     "r" : "3935",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3568",
+                           "r" : "3736",
                            "s" : [ {
-                              "r" : "3570",
+                              "r" : "3738",
                               "s" : [ {
                                  "value" : [ "(" ]
                               }, {
-                                 "r" : "3570",
+                                 "r" : "3738",
                                  "s" : [ {
-                                    "r" : "3569",
+                                    "r" : "3737",
                                     "s" : [ {
                                        "value" : [ "ScreeningDue" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3570",
+                                    "r" : "3738",
                                     "s" : [ {
                                        "value" : [ "DueOrOverdue" ]
                                     } ]
@@ -16040,40 +16824,40 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3643",
+                        "r" : "3811",
                         "s" : [ {
                            "value" : [ "return\n  " ]
                         }, {
-                           "r" : "3644",
+                           "r" : "3812",
                            "s" : [ {
                               "value" : [ "{\n    " ]
                            }, {
                               "s" : [ {
                                  "value" : [ "name",": " ]
                               }, {
-                                 "r" : "3665",
+                                 "r" : "3833",
                                  "s" : [ {
-                                    "r" : "3645",
+                                    "r" : "3813",
                                     "s" : [ {
                                        "value" : [ "Common" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3665",
+                                    "r" : "3833",
                                     "s" : [ {
                                        "value" : [ "ConceptText","(" ]
                                     }, {
-                                       "r" : "3664",
+                                       "r" : "3832",
                                        "s" : [ {
-                                          "r" : "3646",
+                                          "r" : "3814",
                                           "s" : [ {
                                              "value" : [ "R" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3664",
+                                          "r" : "3832",
                                           "s" : [ {
                                              "value" : [ "code" ]
                                           } ]
@@ -16089,16 +16873,16 @@
                               "s" : [ {
                                  "value" : [ "intent",": " ]
                               }, {
-                                 "r" : "3685",
+                                 "r" : "3853",
                                  "s" : [ {
-                                    "r" : "3667",
+                                    "r" : "3835",
                                     "s" : [ {
                                        "value" : [ "R" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3685",
+                                    "r" : "3853",
                                     "s" : [ {
                                        "value" : [ "intent" ]
                                     } ]
@@ -16110,16 +16894,16 @@
                               "s" : [ {
                                  "value" : [ "occurrence",": " ]
                               }, {
-                                 "r" : "3704",
+                                 "r" : "3872",
                                  "s" : [ {
-                                    "r" : "3686",
+                                    "r" : "3854",
                                     "s" : [ {
                                        "value" : [ "R" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3704",
+                                    "r" : "3872",
                                     "s" : [ {
                                        "value" : [ "nextDue" ]
                                     } ]
@@ -16131,18 +16915,18 @@
                               "s" : [ {
                                  "value" : [ "flag",": " ]
                               }, {
-                                 "r" : "3724",
+                                 "r" : "3892",
                                  "s" : [ {
-                                    "r" : "3723",
+                                    "r" : "3891",
                                     "s" : [ {
-                                       "r" : "3705",
+                                       "r" : "3873",
                                        "s" : [ {
                                           "value" : [ "R" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3723",
+                                       "r" : "3891",
                                        "s" : [ {
                                           "value" : [ "flag" ]
                                        } ]
@@ -16150,7 +16934,7 @@
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3724",
+                                    "r" : "3892",
                                     "s" : [ {
                                        "value" : [ "display" ]
                                     } ]
@@ -16162,16 +16946,16 @@
                               "s" : [ {
                                  "value" : [ "plannedRepeat",": " ]
                               }, {
-                                 "r" : "3743",
+                                 "r" : "3911",
                                  "s" : [ {
-                                    "r" : "3725",
+                                    "r" : "3893",
                                     "s" : [ {
                                        "value" : [ "R" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3743",
+                                    "r" : "3911",
                                     "s" : [ {
                                        "value" : [ "plannedRepeat" ]
                                     } ]
@@ -16186,48 +16970,48 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4724",
+               "localId" : "4910",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4725",
+                  "localId" : "4911",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4726",
+                     "localId" : "4912",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4727",
+                        "localId" : "4913",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4728",
+                     "localId" : "4914",
                      "name" : "intent",
                      "elementType" : {
-                        "localId" : "4729",
+                        "localId" : "4915",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4730",
+                     "localId" : "4916",
                      "name" : "occurrence",
                      "elementType" : {
-                        "localId" : "4731",
+                        "localId" : "4917",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4732",
+                     "localId" : "4918",
                      "name" : "flag",
                      "elementType" : {
-                        "localId" : "4733",
+                        "localId" : "4919",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4734",
+                     "localId" : "4920",
                      "name" : "plannedRepeat",
                      "elementType" : {
-                        "localId" : "4735",
+                        "localId" : "4921",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -16235,52 +17019,52 @@
                }
             },
             "expression" : {
-               "localId" : "3767",
+               "localId" : "3935",
                "locator" : "302:3-310:3",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3768",
+                  "localId" : "3936",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3769",
+                     "localId" : "3937",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3770",
+                        "localId" : "3938",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3771",
+                           "localId" : "3939",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3772",
+                        "localId" : "3940",
                         "name" : "intent",
                         "elementType" : {
-                           "localId" : "3773",
+                           "localId" : "3941",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3774",
+                        "localId" : "3942",
                         "name" : "occurrence",
                         "elementType" : {
-                           "localId" : "3775",
+                           "localId" : "3943",
                            "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3776",
+                        "localId" : "3944",
                         "name" : "flag",
                         "elementType" : {
-                           "localId" : "3777",
+                           "localId" : "3945",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3778",
+                        "localId" : "3946",
                         "name" : "plannedRepeat",
                         "elementType" : {
-                           "localId" : "3779",
+                           "localId" : "3947",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -16288,76 +17072,76 @@
                   }
                },
                "source" : [ {
-                  "localId" : "3568",
+                  "localId" : "3736",
                   "locator" : "302:3-302:31",
                   "alias" : "R",
                   "resultTypeSpecifier" : {
-                     "localId" : "3625",
+                     "localId" : "3793",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3626",
+                        "localId" : "3794",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3627",
+                           "localId" : "3795",
                            "name" : "code",
                            "elementType" : {
-                              "localId" : "3628",
+                              "localId" : "3796",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3629",
+                           "localId" : "3797",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3630",
+                              "localId" : "3798",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3631",
+                           "localId" : "3799",
                            "name" : "nextDue",
                            "elementType" : {
-                              "localId" : "3632",
+                              "localId" : "3800",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3633",
+                           "localId" : "3801",
                            "name" : "plannedDue",
                            "elementType" : {
-                              "localId" : "3634",
+                              "localId" : "3802",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3635",
+                           "localId" : "3803",
                            "name" : "plannedStart",
                            "elementType" : {
-                              "localId" : "3636",
+                              "localId" : "3804",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3637",
+                           "localId" : "3805",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3638",
+                              "localId" : "3806",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3639",
+                           "localId" : "3807",
                            "name" : "lastReportDate",
                            "elementType" : {
-                              "localId" : "3640",
+                              "localId" : "3808",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3641",
+                           "localId" : "3809",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3642",
+                              "localId" : "3810",
                               "name" : "{urn:hl7-org:elm-types:r1}Code",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -16365,78 +17149,78 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3570",
+                     "localId" : "3738",
                      "locator" : "302:3-302:29",
                      "name" : "DueOrOverdue",
                      "libraryName" : "ScreeningDue",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3607",
+                        "localId" : "3775",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3608",
+                           "localId" : "3776",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3609",
+                              "localId" : "3777",
                               "name" : "code",
                               "elementType" : {
-                                 "localId" : "3610",
+                                 "localId" : "3778",
                                  "name" : "{http://hl7.org/fhir}CodeableConcept",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3611",
+                              "localId" : "3779",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3612",
+                                 "localId" : "3780",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3613",
+                              "localId" : "3781",
                               "name" : "nextDue",
                               "elementType" : {
-                                 "localId" : "3614",
+                                 "localId" : "3782",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3615",
+                              "localId" : "3783",
                               "name" : "plannedDue",
                               "elementType" : {
-                                 "localId" : "3616",
+                                 "localId" : "3784",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3617",
+                              "localId" : "3785",
                               "name" : "plannedStart",
                               "elementType" : {
-                                 "localId" : "3618",
+                                 "localId" : "3786",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3619",
+                              "localId" : "3787",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3620",
+                                 "localId" : "3788",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3621",
+                              "localId" : "3789",
                               "name" : "lastReportDate",
                               "elementType" : {
-                                 "localId" : "3622",
+                                 "localId" : "3790",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3623",
+                              "localId" : "3791",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3624",
+                                 "localId" : "3792",
                                  "name" : "{urn:hl7-org:elm-types:r1}Code",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -16448,51 +17232,51 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "3643",
+                  "localId" : "3811",
                   "locator" : "303:5-310:3",
                   "resultTypeSpecifier" : {
-                     "localId" : "3755",
+                     "localId" : "3923",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3756",
+                        "localId" : "3924",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3757",
+                           "localId" : "3925",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3758",
+                              "localId" : "3926",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3759",
+                           "localId" : "3927",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3760",
+                              "localId" : "3928",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3761",
+                           "localId" : "3929",
                            "name" : "occurrence",
                            "elementType" : {
-                              "localId" : "3762",
+                              "localId" : "3930",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3763",
+                           "localId" : "3931",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3764",
+                              "localId" : "3932",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3765",
+                           "localId" : "3933",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3766",
+                              "localId" : "3934",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -16500,49 +17284,49 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3644",
+                     "localId" : "3812",
                      "locator" : "304:3-310:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "3744",
+                        "localId" : "3912",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3745",
+                           "localId" : "3913",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3746",
+                              "localId" : "3914",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3747",
+                           "localId" : "3915",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3748",
+                              "localId" : "3916",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3749",
+                           "localId" : "3917",
                            "name" : "occurrence",
                            "elementType" : {
-                              "localId" : "3750",
+                              "localId" : "3918",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3751",
+                           "localId" : "3919",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3752",
+                              "localId" : "3920",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3753",
+                           "localId" : "3921",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3754",
+                              "localId" : "3922",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -16551,19 +17335,19 @@
                      "element" : [ {
                         "name" : "name",
                         "value" : {
-                           "localId" : "3665",
+                           "localId" : "3833",
                            "locator" : "305:11-305:36",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ConceptText",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "3666",
+                              "localId" : "3834",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3664",
+                              "localId" : "3832",
                               "locator" : "305:30-305:35",
                               "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                               "path" : "code",
@@ -16574,7 +17358,7 @@
                      }, {
                         "name" : "intent",
                         "value" : {
-                           "localId" : "3685",
+                           "localId" : "3853",
                            "locator" : "306:13-306:20",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "path" : "intent",
@@ -16584,7 +17368,7 @@
                      }, {
                         "name" : "occurrence",
                         "value" : {
-                           "localId" : "3704",
+                           "localId" : "3872",
                            "locator" : "307:17-307:25",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "path" : "nextDue",
@@ -16594,13 +17378,13 @@
                      }, {
                         "name" : "flag",
                         "value" : {
-                           "localId" : "3724",
+                           "localId" : "3892",
                            "locator" : "308:11-308:24",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "path" : "display",
                            "type" : "Property",
                            "source" : {
-                              "localId" : "3723",
+                              "localId" : "3891",
                               "locator" : "308:11-308:16",
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                               "path" : "flag",
@@ -16611,7 +17395,7 @@
                      }, {
                         "name" : "plannedRepeat",
                         "value" : {
-                           "localId" : "3743",
+                           "localId" : "3911",
                            "locator" : "309:20-309:34",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "path" : "plannedRepeat",
@@ -16623,7 +17407,7 @@
                }
             }
          }, {
-            "localId" : "3806",
+            "localId" : "3974",
             "locator" : "312:1-321:3",
             "name" : "IncompleteScreeningOrdersSummary",
             "context" : "Patient",
@@ -16631,29 +17415,29 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3806",
+                  "r" : "3974",
                   "s" : [ {
                      "value" : [ "","define ","IncompleteScreeningOrdersSummary",":\n  " ]
                   }, {
-                     "r" : "3864",
+                     "r" : "4032",
                      "s" : [ {
                         "s" : [ {
-                           "r" : "3807",
+                           "r" : "3975",
                            "s" : [ {
-                              "r" : "3809",
+                              "r" : "3977",
                               "s" : [ {
                                  "value" : [ "(" ]
                               }, {
-                                 "r" : "3809",
+                                 "r" : "3977",
                                  "s" : [ {
-                                    "r" : "3808",
+                                    "r" : "3976",
                                     "s" : [ {
                                        "value" : [ "ScreeningIncomplete" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3809",
+                                    "r" : "3977",
                                     "s" : [ {
                                        "value" : [ "IncompleteScreeningOrders" ]
                                     } ]
@@ -16668,40 +17452,40 @@
                      }, {
                         "value" : [ "\n    " ]
                      }, {
-                        "r" : "3818",
+                        "r" : "3986",
                         "s" : [ {
                            "value" : [ "return\n  " ]
                         }, {
-                           "r" : "3819",
+                           "r" : "3987",
                            "s" : [ {
                               "value" : [ "{\n    " ]
                            }, {
                               "s" : [ {
                                  "value" : [ "name",": " ]
                               }, {
-                                 "r" : "3823",
+                                 "r" : "3991",
                                  "s" : [ {
-                                    "r" : "3820",
+                                    "r" : "3988",
                                     "s" : [ {
                                        "value" : [ "Common" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3823",
+                                    "r" : "3991",
                                     "s" : [ {
                                        "value" : [ "ConceptText","(" ]
                                     }, {
-                                       "r" : "3822",
+                                       "r" : "3990",
                                        "s" : [ {
-                                          "r" : "3821",
+                                          "r" : "3989",
                                           "s" : [ {
                                              "value" : [ "R" ]
                                           } ]
                                        }, {
                                           "value" : [ "." ]
                                        }, {
-                                          "r" : "3822",
+                                          "r" : "3990",
                                           "s" : [ {
                                              "value" : [ "code" ]
                                           } ]
@@ -16717,16 +17501,16 @@
                               "s" : [ {
                                  "value" : [ "intent",": " ]
                               }, {
-                                 "r" : "3826",
+                                 "r" : "3994",
                                  "s" : [ {
-                                    "r" : "3825",
+                                    "r" : "3993",
                                     "s" : [ {
                                        "value" : [ "R" ]
                                     } ]
                                  }, {
                                     "value" : [ "." ]
                                  }, {
-                                    "r" : "3826",
+                                    "r" : "3994",
                                     "s" : [ {
                                        "value" : [ "intent" ]
                                     } ]
@@ -16738,18 +17522,18 @@
                               "s" : [ {
                                  "value" : [ "occurence",": " ]
                               }, {
-                                 "r" : "3827",
+                                 "r" : "3995",
                                  "s" : [ {
-                                    "r" : "3829",
+                                    "r" : "3997",
                                     "s" : [ {
-                                       "r" : "3828",
+                                       "r" : "3996",
                                        "s" : [ {
                                           "value" : [ "R" ]
                                        } ]
                                     }, {
                                        "value" : [ "." ]
                                     }, {
-                                       "r" : "3829",
+                                       "r" : "3997",
                                        "s" : [ {
                                           "value" : [ "occurrence" ]
                                        } ]
@@ -16757,7 +17541,7 @@
                                  }, {
                                     "value" : [ " as " ]
                                  }, {
-                                    "r" : "3838",
+                                    "r" : "4006",
                                     "s" : [ {
                                        "value" : [ "FHIR",".","dateTime" ]
                                     } ]
@@ -16767,14 +17551,14 @@
                               "value" : [ ",\n    " ]
                            }, {
                               "s" : [ {
-                                 "r" : "3839",
+                                 "r" : "4007",
                                  "value" : [ "flag",": ","null" ]
                               } ]
                            }, {
                               "value" : [ ",\n    " ]
                            }, {
                               "s" : [ {
-                                 "r" : "3840",
+                                 "r" : "4008",
                                  "value" : [ "plannedRepeat",": ","null" ]
                               } ]
                            }, {
@@ -16786,48 +17570,48 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4736",
+               "localId" : "4922",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4737",
+                  "localId" : "4923",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4738",
+                     "localId" : "4924",
                      "name" : "name",
                      "elementType" : {
-                        "localId" : "4739",
+                        "localId" : "4925",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4740",
+                     "localId" : "4926",
                      "name" : "intent",
                      "elementType" : {
-                        "localId" : "4741",
+                        "localId" : "4927",
                         "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4742",
+                     "localId" : "4928",
                      "name" : "occurence",
                      "elementType" : {
-                        "localId" : "4743",
+                        "localId" : "4929",
                         "name" : "{http://hl7.org/fhir}dateTime",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4744",
+                     "localId" : "4930",
                      "name" : "flag",
                      "elementType" : {
-                        "localId" : "4745",
+                        "localId" : "4931",
                         "name" : "{urn:hl7-org:elm-types:r1}Any",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "4746",
+                     "localId" : "4932",
                      "name" : "plannedRepeat",
                      "elementType" : {
-                        "localId" : "4747",
+                        "localId" : "4933",
                         "name" : "{urn:hl7-org:elm-types:r1}Any",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -16835,52 +17619,52 @@
                }
             },
             "expression" : {
-               "localId" : "3864",
+               "localId" : "4032",
                "locator" : "313:3-321:3",
                "type" : "Query",
                "resultTypeSpecifier" : {
-                  "localId" : "3865",
+                  "localId" : "4033",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3866",
+                     "localId" : "4034",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "3867",
+                        "localId" : "4035",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "3868",
+                           "localId" : "4036",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3869",
+                        "localId" : "4037",
                         "name" : "intent",
                         "elementType" : {
-                           "localId" : "3870",
+                           "localId" : "4038",
                            "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3871",
+                        "localId" : "4039",
                         "name" : "occurence",
                         "elementType" : {
-                           "localId" : "3872",
+                           "localId" : "4040",
                            "name" : "{http://hl7.org/fhir}dateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3873",
+                        "localId" : "4041",
                         "name" : "flag",
                         "elementType" : {
-                           "localId" : "3874",
+                           "localId" : "4042",
                            "name" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "3875",
+                        "localId" : "4043",
                         "name" : "plannedRepeat",
                         "elementType" : {
-                           "localId" : "3876",
+                           "localId" : "4044",
                            "name" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -16888,29 +17672,29 @@
                   }
                },
                "source" : [ {
-                  "localId" : "3807",
+                  "localId" : "3975",
                   "locator" : "313:3-313:51",
                   "alias" : "R",
                   "resultTypeSpecifier" : {
-                     "localId" : "3816",
+                     "localId" : "3984",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3817",
+                        "localId" : "3985",
                         "name" : "{http://hl7.org/fhir}ServiceRequest",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "expression" : {
-                     "localId" : "3809",
+                     "localId" : "3977",
                      "locator" : "313:3-313:49",
                      "name" : "IncompleteScreeningOrders",
                      "libraryName" : "ScreeningIncomplete",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3814",
+                        "localId" : "3982",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3815",
+                           "localId" : "3983",
                            "name" : "{http://hl7.org/fhir}ServiceRequest",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -16920,51 +17704,51 @@
                "let" : [ ],
                "relationship" : [ ],
                "return" : {
-                  "localId" : "3818",
+                  "localId" : "3986",
                   "locator" : "314:5-321:3",
                   "resultTypeSpecifier" : {
-                     "localId" : "3852",
+                     "localId" : "4020",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3853",
+                        "localId" : "4021",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3854",
+                           "localId" : "4022",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3855",
+                              "localId" : "4023",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3856",
+                           "localId" : "4024",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3857",
+                              "localId" : "4025",
                               "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3858",
+                           "localId" : "4026",
                            "name" : "occurence",
                            "elementType" : {
-                              "localId" : "3859",
+                              "localId" : "4027",
                               "name" : "{http://hl7.org/fhir}dateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3860",
+                           "localId" : "4028",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3861",
+                              "localId" : "4029",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3862",
+                           "localId" : "4030",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3863",
+                              "localId" : "4031",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -16972,49 +17756,49 @@
                      }
                   },
                   "expression" : {
-                     "localId" : "3819",
+                     "localId" : "3987",
                      "locator" : "315:3-321:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "3841",
+                        "localId" : "4009",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3842",
+                           "localId" : "4010",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3843",
+                              "localId" : "4011",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3844",
+                           "localId" : "4012",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3845",
+                              "localId" : "4013",
                               "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3846",
+                           "localId" : "4014",
                            "name" : "occurence",
                            "elementType" : {
-                              "localId" : "3847",
+                              "localId" : "4015",
                               "name" : "{http://hl7.org/fhir}dateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3848",
+                           "localId" : "4016",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3849",
+                              "localId" : "4017",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3850",
+                           "localId" : "4018",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3851",
+                              "localId" : "4019",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -17023,19 +17807,19 @@
                      "element" : [ {
                         "name" : "name",
                         "value" : {
-                           "localId" : "3823",
+                           "localId" : "3991",
                            "locator" : "316:11-316:36",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                            "name" : "ConceptText",
                            "libraryName" : "Common",
                            "type" : "FunctionRef",
                            "signature" : [ {
-                              "localId" : "3824",
+                              "localId" : "3992",
                               "name" : "{http://hl7.org/fhir}CodeableConcept",
                               "type" : "NamedTypeSpecifier"
                            } ],
                            "operand" : [ {
-                              "localId" : "3822",
+                              "localId" : "3990",
                               "locator" : "316:30-316:35",
                               "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
                               "path" : "code",
@@ -17046,7 +17830,7 @@
                      }, {
                         "name" : "intent",
                         "value" : {
-                           "localId" : "3826",
+                           "localId" : "3994",
                            "locator" : "317:13-317:20",
                            "resultTypeName" : "{http://hl7.org/fhir}ServiceRequestIntent",
                            "path" : "intent",
@@ -17056,39 +17840,39 @@
                      }, {
                         "name" : "occurence",
                         "value" : {
-                           "localId" : "3827",
+                           "localId" : "3995",
                            "locator" : "318:16-318:44",
                            "resultTypeName" : "{http://hl7.org/fhir}dateTime",
                            "strict" : false,
                            "type" : "As",
                            "signature" : [ ],
                            "operand" : {
-                              "localId" : "3829",
+                              "localId" : "3997",
                               "locator" : "318:16-318:27",
                               "path" : "occurrence",
                               "scope" : "R",
                               "type" : "Property",
                               "resultTypeSpecifier" : {
-                                 "localId" : "3834",
+                                 "localId" : "4002",
                                  "type" : "ChoiceTypeSpecifier",
                                  "type" : [ ],
                                  "choice" : [ {
-                                    "localId" : "3835",
+                                    "localId" : "4003",
                                     "name" : "{http://hl7.org/fhir}dateTime",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3836",
+                                    "localId" : "4004",
                                     "name" : "{http://hl7.org/fhir}Period",
                                     "type" : "NamedTypeSpecifier"
                                  }, {
-                                    "localId" : "3837",
+                                    "localId" : "4005",
                                     "name" : "{http://hl7.org/fhir}Timing",
                                     "type" : "NamedTypeSpecifier"
                                  } ]
                               }
                            },
                            "asTypeSpecifier" : {
-                              "localId" : "3838",
+                              "localId" : "4006",
                               "locator" : "318:32-318:44",
                               "resultTypeName" : "{http://hl7.org/fhir}dateTime",
                               "name" : "{http://hl7.org/fhir}dateTime",
@@ -17098,7 +17882,7 @@
                      }, {
                         "name" : "flag",
                         "value" : {
-                           "localId" : "3839",
+                           "localId" : "4007",
                            "locator" : "319:11-319:14",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "Null"
@@ -17106,7 +17890,7 @@
                      }, {
                         "name" : "plannedRepeat",
                         "value" : {
-                           "localId" : "3840",
+                           "localId" : "4008",
                            "locator" : "320:20-320:23",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "Null"
@@ -17116,7 +17900,7 @@
                }
             }
          }, {
-            "localId" : "3565",
+            "localId" : "3733",
             "locator" : "323:1-325:36",
             "name" : "PertinentRequestsSummary",
             "context" : "Patient",
@@ -17124,20 +17908,20 @@
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "3565",
+                  "r" : "3733",
                   "s" : [ {
                      "value" : [ "","define ","PertinentRequestsSummary",":\n  " ]
                   }, {
-                     "r" : "3952",
+                     "r" : "4120",
                      "s" : [ {
-                        "r" : "3792",
+                        "r" : "3960",
                         "s" : [ {
                            "value" : [ "DueOrOverdueScreeningSummary" ]
                         } ]
                      }, {
                         "value" : [ " union\n    " ]
                      }, {
-                        "r" : "3889",
+                        "r" : "4057",
                         "s" : [ {
                            "value" : [ "IncompleteScreeningOrdersSummary" ]
                         } ]
@@ -17146,96 +17930,96 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4748",
+               "localId" : "4934",
                "type" : "ListTypeSpecifier",
                "elementType" : {
-                  "localId" : "4749",
+                  "localId" : "4935",
                   "type" : "ChoiceTypeSpecifier",
                   "type" : [ ],
                   "choice" : [ {
-                     "localId" : "4750",
+                     "localId" : "4936",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4751",
+                        "localId" : "4937",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "4752",
+                           "localId" : "4938",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4753",
+                        "localId" : "4939",
                         "name" : "intent",
                         "elementType" : {
-                           "localId" : "4754",
+                           "localId" : "4940",
                            "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4755",
+                        "localId" : "4941",
                         "name" : "occurence",
                         "elementType" : {
-                           "localId" : "4756",
+                           "localId" : "4942",
                            "name" : "{http://hl7.org/fhir}dateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4757",
+                        "localId" : "4943",
                         "name" : "flag",
                         "elementType" : {
-                           "localId" : "4758",
+                           "localId" : "4944",
                            "name" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4759",
+                        "localId" : "4945",
                         "name" : "plannedRepeat",
                         "elementType" : {
-                           "localId" : "4760",
+                           "localId" : "4946",
                            "name" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ]
                   }, {
-                     "localId" : "4761",
+                     "localId" : "4947",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4762",
+                        "localId" : "4948",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "4763",
+                           "localId" : "4949",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4764",
+                        "localId" : "4950",
                         "name" : "intent",
                         "elementType" : {
-                           "localId" : "4765",
+                           "localId" : "4951",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4766",
+                        "localId" : "4952",
                         "name" : "occurrence",
                         "elementType" : {
-                           "localId" : "4767",
+                           "localId" : "4953",
                            "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4768",
+                        "localId" : "4954",
                         "name" : "flag",
                         "elementType" : {
-                           "localId" : "4769",
+                           "localId" : "4955",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4770",
+                        "localId" : "4956",
                         "name" : "plannedRepeat",
                         "elementType" : {
-                           "localId" : "4771",
+                           "localId" : "4957",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -17244,100 +18028,100 @@
                }
             },
             "expression" : {
-               "localId" : "3952",
+               "localId" : "4120",
                "locator" : "324:3-325:36",
                "type" : "Union",
                "resultTypeSpecifier" : {
-                  "localId" : "4001",
+                  "localId" : "4169",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "4002",
+                     "localId" : "4170",
                      "type" : "ChoiceTypeSpecifier",
                      "type" : [ ],
                      "choice" : [ {
-                        "localId" : "4003",
+                        "localId" : "4171",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4004",
+                           "localId" : "4172",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "4005",
+                              "localId" : "4173",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4006",
+                           "localId" : "4174",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "4007",
+                              "localId" : "4175",
                               "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4008",
+                           "localId" : "4176",
                            "name" : "occurence",
                            "elementType" : {
-                              "localId" : "4009",
+                              "localId" : "4177",
                               "name" : "{http://hl7.org/fhir}dateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4010",
+                           "localId" : "4178",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "4011",
+                              "localId" : "4179",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4012",
+                           "localId" : "4180",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "4013",
+                              "localId" : "4181",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      }, {
-                        "localId" : "4014",
+                        "localId" : "4182",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4015",
+                           "localId" : "4183",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "4016",
+                              "localId" : "4184",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4017",
+                           "localId" : "4185",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "4018",
+                              "localId" : "4186",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4019",
+                           "localId" : "4187",
                            "name" : "occurrence",
                            "elementType" : {
-                              "localId" : "4020",
+                              "localId" : "4188",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4021",
+                           "localId" : "4189",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "4022",
+                              "localId" : "4190",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4023",
+                           "localId" : "4191",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "4024",
+                              "localId" : "4192",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -17346,96 +18130,96 @@
                   }
                },
                "signature" : [ {
-                  "localId" : "3953",
+                  "localId" : "4121",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3954",
+                     "localId" : "4122",
                      "type" : "ChoiceTypeSpecifier",
                      "type" : [ ],
                      "choice" : [ {
-                        "localId" : "3955",
+                        "localId" : "4123",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3956",
+                           "localId" : "4124",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3957",
+                              "localId" : "4125",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3958",
+                           "localId" : "4126",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3959",
+                              "localId" : "4127",
                               "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3960",
+                           "localId" : "4128",
                            "name" : "occurence",
                            "elementType" : {
-                              "localId" : "3961",
+                              "localId" : "4129",
                               "name" : "{http://hl7.org/fhir}dateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3962",
+                           "localId" : "4130",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3963",
+                              "localId" : "4131",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3964",
+                           "localId" : "4132",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3965",
+                              "localId" : "4133",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      }, {
-                        "localId" : "3966",
+                        "localId" : "4134",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3967",
+                           "localId" : "4135",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3968",
+                              "localId" : "4136",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3969",
+                           "localId" : "4137",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3970",
+                              "localId" : "4138",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3971",
+                           "localId" : "4139",
                            "name" : "occurrence",
                            "elementType" : {
-                              "localId" : "3972",
+                              "localId" : "4140",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3973",
+                           "localId" : "4141",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3974",
+                              "localId" : "4142",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3975",
+                           "localId" : "4143",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3976",
+                              "localId" : "4144",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -17443,96 +18227,96 @@
                      } ]
                   }
                }, {
-                  "localId" : "3977",
+                  "localId" : "4145",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "3978",
+                     "localId" : "4146",
                      "type" : "ChoiceTypeSpecifier",
                      "type" : [ ],
                      "choice" : [ {
-                        "localId" : "3979",
+                        "localId" : "4147",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3980",
+                           "localId" : "4148",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3981",
+                              "localId" : "4149",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3982",
+                           "localId" : "4150",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3983",
+                              "localId" : "4151",
                               "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3984",
+                           "localId" : "4152",
                            "name" : "occurence",
                            "elementType" : {
-                              "localId" : "3985",
+                              "localId" : "4153",
                               "name" : "{http://hl7.org/fhir}dateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3986",
+                           "localId" : "4154",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3987",
+                              "localId" : "4155",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3988",
+                           "localId" : "4156",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "3989",
+                              "localId" : "4157",
                               "name" : "{urn:hl7-org:elm-types:r1}Any",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      }, {
-                        "localId" : "3990",
+                        "localId" : "4158",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "3991",
+                           "localId" : "4159",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "3992",
+                              "localId" : "4160",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3993",
+                           "localId" : "4161",
                            "name" : "intent",
                            "elementType" : {
-                              "localId" : "3994",
+                              "localId" : "4162",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3995",
+                           "localId" : "4163",
                            "name" : "occurrence",
                            "elementType" : {
-                              "localId" : "3996",
+                              "localId" : "4164",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3997",
+                           "localId" : "4165",
                            "name" : "flag",
                            "elementType" : {
-                              "localId" : "3998",
+                              "localId" : "4166",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "3999",
+                           "localId" : "4167",
                            "name" : "plannedRepeat",
                            "elementType" : {
-                              "localId" : "4000",
+                              "localId" : "4168",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
@@ -17541,57 +18325,57 @@
                   }
                } ],
                "operand" : [ {
-                  "localId" : "3902",
+                  "localId" : "4070",
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "3792",
+                     "localId" : "3960",
                      "locator" : "324:3-324:30",
                      "name" : "DueOrOverdueScreeningSummary",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3793",
+                        "localId" : "3961",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3794",
+                           "localId" : "3962",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3795",
+                              "localId" : "3963",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3796",
+                                 "localId" : "3964",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3797",
+                              "localId" : "3965",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3798",
+                                 "localId" : "3966",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3799",
+                              "localId" : "3967",
                               "name" : "occurrence",
                               "elementType" : {
-                                 "localId" : "3800",
+                                 "localId" : "3968",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3801",
+                              "localId" : "3969",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3802",
+                                 "localId" : "3970",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3803",
+                              "localId" : "3971",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3804",
+                                 "localId" : "3972",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -17600,96 +18384,96 @@
                      }
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "3903",
+                     "localId" : "4071",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3904",
+                        "localId" : "4072",
                         "type" : "ChoiceTypeSpecifier",
                         "type" : [ ],
                         "choice" : [ {
-                           "localId" : "3905",
+                           "localId" : "4073",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3906",
+                              "localId" : "4074",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3907",
+                                 "localId" : "4075",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3908",
+                              "localId" : "4076",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3909",
+                                 "localId" : "4077",
                                  "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3910",
+                              "localId" : "4078",
                               "name" : "occurence",
                               "elementType" : {
-                                 "localId" : "3911",
+                                 "localId" : "4079",
                                  "name" : "{http://hl7.org/fhir}dateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3912",
+                              "localId" : "4080",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3913",
+                                 "localId" : "4081",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3914",
+                              "localId" : "4082",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3915",
+                                 "localId" : "4083",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
                            } ]
                         }, {
-                           "localId" : "3916",
+                           "localId" : "4084",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3917",
+                              "localId" : "4085",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3918",
+                                 "localId" : "4086",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3919",
+                              "localId" : "4087",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3920",
+                                 "localId" : "4088",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3921",
+                              "localId" : "4089",
                               "name" : "occurrence",
                               "elementType" : {
-                                 "localId" : "3922",
+                                 "localId" : "4090",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3923",
+                              "localId" : "4091",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3924",
+                                 "localId" : "4092",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3925",
+                              "localId" : "4093",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3926",
+                                 "localId" : "4094",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -17698,57 +18482,57 @@
                      }
                   }
                }, {
-                  "localId" : "3927",
+                  "localId" : "4095",
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "3889",
+                     "localId" : "4057",
                      "locator" : "325:5-325:36",
                      "name" : "IncompleteScreeningOrdersSummary",
                      "type" : "ExpressionRef",
                      "resultTypeSpecifier" : {
-                        "localId" : "3890",
+                        "localId" : "4058",
                         "type" : "ListTypeSpecifier",
                         "elementType" : {
-                           "localId" : "3891",
+                           "localId" : "4059",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3892",
+                              "localId" : "4060",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3893",
+                                 "localId" : "4061",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3894",
+                              "localId" : "4062",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3895",
+                                 "localId" : "4063",
                                  "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3896",
+                              "localId" : "4064",
                               "name" : "occurence",
                               "elementType" : {
-                                 "localId" : "3897",
+                                 "localId" : "4065",
                                  "name" : "{http://hl7.org/fhir}dateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3898",
+                              "localId" : "4066",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3899",
+                                 "localId" : "4067",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3900",
+                              "localId" : "4068",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3901",
+                                 "localId" : "4069",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -17757,96 +18541,96 @@
                      }
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "3928",
+                     "localId" : "4096",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "3929",
+                        "localId" : "4097",
                         "type" : "ChoiceTypeSpecifier",
                         "type" : [ ],
                         "choice" : [ {
-                           "localId" : "3930",
+                           "localId" : "4098",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3931",
+                              "localId" : "4099",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3932",
+                                 "localId" : "4100",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3933",
+                              "localId" : "4101",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3934",
+                                 "localId" : "4102",
                                  "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3935",
+                              "localId" : "4103",
                               "name" : "occurence",
                               "elementType" : {
-                                 "localId" : "3936",
+                                 "localId" : "4104",
                                  "name" : "{http://hl7.org/fhir}dateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3937",
+                              "localId" : "4105",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3938",
+                                 "localId" : "4106",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3939",
+                              "localId" : "4107",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3940",
+                                 "localId" : "4108",
                                  "name" : "{urn:hl7-org:elm-types:r1}Any",
                                  "type" : "NamedTypeSpecifier"
                               }
                            } ]
                         }, {
-                           "localId" : "3941",
+                           "localId" : "4109",
                            "type" : "TupleTypeSpecifier",
                            "element" : [ {
-                              "localId" : "3942",
+                              "localId" : "4110",
                               "name" : "name",
                               "elementType" : {
-                                 "localId" : "3943",
+                                 "localId" : "4111",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3944",
+                              "localId" : "4112",
                               "name" : "intent",
                               "elementType" : {
-                                 "localId" : "3945",
+                                 "localId" : "4113",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3946",
+                              "localId" : "4114",
                               "name" : "occurrence",
                               "elementType" : {
-                                 "localId" : "3947",
+                                 "localId" : "4115",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3948",
+                              "localId" : "4116",
                               "name" : "flag",
                               "elementType" : {
-                                 "localId" : "3949",
+                                 "localId" : "4117",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }, {
-                              "localId" : "3950",
+                              "localId" : "4118",
                               "name" : "plannedRepeat",
                               "elementType" : {
-                                 "localId" : "3951",
+                                 "localId" : "4119",
                                  "name" : "{urn:hl7-org:elm-types:r1}String",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -18087,7 +18871,7 @@
                               "s" : [ {
                                  "value" : [ "diagnosticReports",": " ]
                               }, {
-                                 "r" : "3228",
+                                 "r" : "3394",
                                  "s" : [ {
                                     "value" : [ "DiagnosticReportsSummary" ]
                                  } ]
@@ -18098,7 +18882,7 @@
                               "s" : [ {
                                  "value" : [ "encounters",": " ]
                               }, {
-                                 "r" : "3357",
+                                 "r" : "3525",
                                  "s" : [ {
                                     "value" : [ "PertinentEncountersSummary" ]
                                  } ]
@@ -18109,7 +18893,7 @@
                               "s" : [ {
                                  "value" : [ "episodeOfCares",": " ]
                               }, {
-                                 "r" : "3550",
+                                 "r" : "3718",
                                  "s" : [ {
                                     "value" : [ "PertinentEpisodesOfCareSummary" ]
                                  } ]
@@ -18120,7 +18904,7 @@
                               "s" : [ {
                                  "value" : [ "requests",": " ]
                               }, {
-                                 "r" : "4049",
+                                 "r" : "4217",
                                  "s" : [ {
                                     "value" : [ "PertinentRequestsSummary" ]
                                  } ]
@@ -18136,147 +18920,147 @@
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "4347",
+               "localId" : "4519",
                "type" : "TupleTypeSpecifier",
                "element" : [ {
-                  "localId" : "4348",
+                  "localId" : "4520",
                   "name" : "patientInfo",
                   "elementType" : {
-                     "localId" : "4349",
+                     "localId" : "4521",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4350",
+                        "localId" : "4522",
                         "name" : "name",
                         "elementType" : {
-                           "localId" : "4351",
+                           "localId" : "4523",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4352",
+                        "localId" : "4524",
                         "name" : "id",
                         "elementType" : {
-                           "localId" : "4353",
+                           "localId" : "4525",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4354",
+                              "localId" : "4526",
                               "name" : "{http://hl7.org/fhir}Identifier",
                               "type" : "NamedTypeSpecifier"
                            }
                         }
                      }, {
-                        "localId" : "4355",
+                        "localId" : "4527",
                         "name" : "isPregnant",
                         "elementType" : {
-                           "localId" : "4356",
+                           "localId" : "4528",
                            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4357",
+                        "localId" : "4529",
                         "name" : "dateOfBirth",
                         "elementType" : {
-                           "localId" : "4358",
+                           "localId" : "4530",
                            "name" : "{http://hl7.org/fhir}date",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4359",
+                        "localId" : "4531",
                         "name" : "sexAtBirth",
                         "elementType" : {
-                           "localId" : "4360",
+                           "localId" : "4532",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4361",
+                        "localId" : "4533",
                         "name" : "age",
                         "elementType" : {
-                           "localId" : "4362",
+                           "localId" : "4534",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4363",
+                        "localId" : "4535",
                         "name" : "gender",
                         "elementType" : {
-                           "localId" : "4364",
+                           "localId" : "4536",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4365",
+                        "localId" : "4537",
                         "name" : "primaryLanguage",
                         "elementType" : {
-                           "localId" : "4366",
+                           "localId" : "4538",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "localId" : "4367",
+                        "localId" : "4539",
                         "name" : "race",
                         "elementType" : {
-                           "localId" : "4368",
+                           "localId" : "4540",
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
                      } ]
                   }
                }, {
-                  "localId" : "4369",
+                  "localId" : "4541",
                   "name" : "patientHistory",
                   "elementType" : {
-                     "localId" : "4370",
+                     "localId" : "4542",
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
-                        "localId" : "4371",
+                        "localId" : "4543",
                         "name" : "conditions",
                         "elementType" : {
-                           "localId" : "4372",
+                           "localId" : "4544",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4373",
+                              "localId" : "4545",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4374",
+                                 "localId" : "4546",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4375",
+                                    "localId" : "4547",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4376",
+                                 "localId" : "4548",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4377",
+                                    "localId" : "4549",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4378",
+                                 "localId" : "4550",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4379",
+                                    "localId" : "4551",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4380",
+                                 "localId" : "4552",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4381",
+                                    "localId" : "4553",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4382",
+                                 "localId" : "4554",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "4383",
+                                    "localId" : "4555",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4384",
+                                       "localId" : "4556",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18285,57 +19069,57 @@
                            }
                         }
                      }, {
-                        "localId" : "4385",
+                        "localId" : "4557",
                         "name" : "familyMemberHistory",
                         "elementType" : {
-                           "localId" : "4386",
+                           "localId" : "4558",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4387",
+                              "localId" : "4559",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4388",
+                                 "localId" : "4560",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4389",
+                                    "localId" : "4561",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4390",
+                                       "localId" : "4562",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4391",
+                                    "localId" : "4563",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4392",
+                                       "localId" : "4564",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4393",
+                                    "localId" : "4565",
                                     "name" : "onset",
                                     "elementType" : {
-                                       "localId" : "4394",
+                                       "localId" : "4566",
                                        "name" : "{urn:hl7-org:elm-types:r1}Any",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4395",
+                                    "localId" : "4567",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4396",
+                                       "localId" : "4568",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4397",
+                                    "localId" : "4569",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4398",
+                                       "localId" : "4570",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4399",
+                                          "localId" : "4571",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -18345,54 +19129,54 @@
                            }
                         }
                      }, {
-                        "localId" : "4400",
+                        "localId" : "4572",
                         "name" : "observations",
                         "elementType" : {
-                           "localId" : "4401",
+                           "localId" : "4573",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4402",
+                              "localId" : "4574",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4403",
+                                 "localId" : "4575",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4404",
+                                    "localId" : "4576",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4405",
+                                 "localId" : "4577",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4406",
+                                    "localId" : "4578",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4407",
+                                 "localId" : "4579",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4408",
+                                    "localId" : "4580",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4409",
+                                 "localId" : "4581",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4410",
+                                    "localId" : "4582",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4411",
+                                 "localId" : "4583",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "4412",
+                                    "localId" : "4584",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4413",
+                                       "localId" : "4585",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18401,54 +19185,54 @@
                            }
                         }
                      }, {
-                        "localId" : "4414",
+                        "localId" : "4586",
                         "name" : "procedures",
                         "elementType" : {
-                           "localId" : "4415",
+                           "localId" : "4587",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4416",
+                              "localId" : "4588",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4417",
+                                 "localId" : "4589",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4418",
+                                    "localId" : "4590",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4419",
+                                 "localId" : "4591",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4420",
+                                    "localId" : "4592",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4421",
+                                 "localId" : "4593",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4422",
+                                    "localId" : "4594",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4423",
+                                 "localId" : "4595",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4424",
+                                    "localId" : "4596",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4425",
+                                 "localId" : "4597",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "4426",
+                                    "localId" : "4598",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4427",
+                                       "localId" : "4599",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18457,66 +19241,74 @@
                            }
                         }
                      }, {
-                        "localId" : "4428",
+                        "localId" : "4600",
                         "name" : "diagnosticReports",
                         "elementType" : {
-                           "localId" : "4429",
+                           "localId" : "4601",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4430",
+                              "localId" : "4602",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4431",
+                                 "localId" : "4603",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4432",
+                                    "localId" : "4604",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4433",
+                                 "localId" : "4605",
                                  "name" : "longName",
                                  "elementType" : {
-                                    "localId" : "4434",
+                                    "localId" : "4606",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4435",
+                                 "localId" : "4607",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4436",
+                                    "localId" : "4608",
+                                    "name" : "{http://hl7.org/fhir}string",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }, {
+                                 "localId" : "4609",
+                                 "name" : "longValue",
+                                 "elementType" : {
+                                    "localId" : "4610",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4437",
-                                       "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                       "localId" : "4611",
+                                       "name" : "{http://hl7.org/fhir}string",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }
                               }, {
-                                 "localId" : "4438",
+                                 "localId" : "4612",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4439",
+                                    "localId" : "4613",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4440",
+                                 "localId" : "4614",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4441",
+                                    "localId" : "4615",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4442",
+                                 "localId" : "4616",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "4443",
+                                    "localId" : "4617",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4444",
+                                       "localId" : "4618",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18525,43 +19317,43 @@
                            }
                         }
                      }, {
-                        "localId" : "4445",
+                        "localId" : "4619",
                         "name" : "encounters",
                         "elementType" : {
-                           "localId" : "4446",
+                           "localId" : "4620",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4447",
+                              "localId" : "4621",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4448",
+                                 "localId" : "4622",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4449",
+                                    "localId" : "4623",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4450",
+                                 "localId" : "4624",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4451",
+                                    "localId" : "4625",
                                     "name" : "{http://hl7.org/fhir}EncounterStatus",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4452",
+                                 "localId" : "4626",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4453",
+                                    "localId" : "4627",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4454",
+                                 "localId" : "4628",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4455",
+                                    "localId" : "4629",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
@@ -18569,54 +19361,54 @@
                            }
                         }
                      }, {
-                        "localId" : "4456",
+                        "localId" : "4630",
                         "name" : "episodeOfCares",
                         "elementType" : {
-                           "localId" : "4457",
+                           "localId" : "4631",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4458",
+                              "localId" : "4632",
                               "type" : "TupleTypeSpecifier",
                               "element" : [ {
-                                 "localId" : "4459",
+                                 "localId" : "4633",
                                  "name" : "name",
                                  "elementType" : {
-                                    "localId" : "4460",
+                                    "localId" : "4634",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4461",
+                                 "localId" : "4635",
                                  "name" : "value",
                                  "elementType" : {
-                                    "localId" : "4462",
+                                    "localId" : "4636",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4463",
+                                 "localId" : "4637",
                                  "name" : "date",
                                  "elementType" : {
-                                    "localId" : "4464",
+                                    "localId" : "4638",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4465",
+                                 "localId" : "4639",
                                  "name" : "reference",
                                  "elementType" : {
-                                    "localId" : "4466",
+                                    "localId" : "4640",
                                     "name" : "{urn:hl7-org:elm-types:r1}String",
                                     "type" : "NamedTypeSpecifier"
                                  }
                               }, {
-                                 "localId" : "4467",
+                                 "localId" : "4641",
                                  "name" : "edited",
                                  "elementType" : {
-                                    "localId" : "4468",
+                                    "localId" : "4642",
                                     "type" : "ListTypeSpecifier",
                                     "elementType" : {
-                                       "localId" : "4469",
+                                       "localId" : "4643",
                                        "name" : "{http://hl7.org/fhir}Extension",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18625,99 +19417,99 @@
                            }
                         }
                      }, {
-                        "localId" : "4470",
+                        "localId" : "4644",
                         "name" : "requests",
                         "elementType" : {
-                           "localId" : "4471",
+                           "localId" : "4645",
                            "type" : "ListTypeSpecifier",
                            "elementType" : {
-                              "localId" : "4472",
+                              "localId" : "4646",
                               "type" : "ChoiceTypeSpecifier",
                               "type" : [ ],
                               "choice" : [ {
-                                 "localId" : "4473",
+                                 "localId" : "4647",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4474",
+                                    "localId" : "4648",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4475",
+                                       "localId" : "4649",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4476",
+                                    "localId" : "4650",
                                     "name" : "intent",
                                     "elementType" : {
-                                       "localId" : "4477",
+                                       "localId" : "4651",
                                        "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4478",
+                                    "localId" : "4652",
                                     "name" : "occurence",
                                     "elementType" : {
-                                       "localId" : "4479",
+                                       "localId" : "4653",
                                        "name" : "{http://hl7.org/fhir}dateTime",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4480",
+                                    "localId" : "4654",
                                     "name" : "flag",
                                     "elementType" : {
-                                       "localId" : "4481",
+                                       "localId" : "4655",
                                        "name" : "{urn:hl7-org:elm-types:r1}Any",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4482",
+                                    "localId" : "4656",
                                     "name" : "plannedRepeat",
                                     "elementType" : {
-                                       "localId" : "4483",
+                                       "localId" : "4657",
                                        "name" : "{urn:hl7-org:elm-types:r1}Any",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  } ]
                               }, {
-                                 "localId" : "4484",
+                                 "localId" : "4658",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4485",
+                                    "localId" : "4659",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4486",
+                                       "localId" : "4660",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4487",
+                                    "localId" : "4661",
                                     "name" : "intent",
                                     "elementType" : {
-                                       "localId" : "4488",
+                                       "localId" : "4662",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4489",
+                                    "localId" : "4663",
                                     "name" : "occurrence",
                                     "elementType" : {
-                                       "localId" : "4490",
+                                       "localId" : "4664",
                                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4491",
+                                    "localId" : "4665",
                                     "name" : "flag",
                                     "elementType" : {
-                                       "localId" : "4492",
+                                       "localId" : "4666",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4493",
+                                    "localId" : "4667",
                                     "name" : "plannedRepeat",
                                     "elementType" : {
-                                       "localId" : "4494",
+                                       "localId" : "4668",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -18734,147 +19526,147 @@
                "locator" : "29:1-51:1",
                "type" : "Tuple",
                "resultTypeSpecifier" : {
-                  "localId" : "4199",
+                  "localId" : "4369",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "4200",
+                     "localId" : "4370",
                      "name" : "patientInfo",
                      "elementType" : {
-                        "localId" : "4201",
+                        "localId" : "4371",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4202",
+                           "localId" : "4372",
                            "name" : "name",
                            "elementType" : {
-                              "localId" : "4203",
+                              "localId" : "4373",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4204",
+                           "localId" : "4374",
                            "name" : "id",
                            "elementType" : {
-                              "localId" : "4205",
+                              "localId" : "4375",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4206",
+                                 "localId" : "4376",
                                  "name" : "{http://hl7.org/fhir}Identifier",
                                  "type" : "NamedTypeSpecifier"
                               }
                            }
                         }, {
-                           "localId" : "4207",
+                           "localId" : "4377",
                            "name" : "isPregnant",
                            "elementType" : {
-                              "localId" : "4208",
+                              "localId" : "4378",
                               "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4209",
+                           "localId" : "4379",
                            "name" : "dateOfBirth",
                            "elementType" : {
-                              "localId" : "4210",
+                              "localId" : "4380",
                               "name" : "{http://hl7.org/fhir}date",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4211",
+                           "localId" : "4381",
                            "name" : "sexAtBirth",
                            "elementType" : {
-                              "localId" : "4212",
+                              "localId" : "4382",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4213",
+                           "localId" : "4383",
                            "name" : "age",
                            "elementType" : {
-                              "localId" : "4214",
+                              "localId" : "4384",
                               "name" : "{urn:hl7-org:elm-types:r1}Integer",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4215",
+                           "localId" : "4385",
                            "name" : "gender",
                            "elementType" : {
-                              "localId" : "4216",
+                              "localId" : "4386",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4217",
+                           "localId" : "4387",
                            "name" : "primaryLanguage",
                            "elementType" : {
-                              "localId" : "4218",
+                              "localId" : "4388",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         }, {
-                           "localId" : "4219",
+                           "localId" : "4389",
                            "name" : "race",
                            "elementType" : {
-                              "localId" : "4220",
+                              "localId" : "4390",
                               "name" : "{urn:hl7-org:elm-types:r1}String",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ]
                      }
                   }, {
-                     "localId" : "4221",
+                     "localId" : "4391",
                      "name" : "patientHistory",
                      "elementType" : {
-                        "localId" : "4222",
+                        "localId" : "4392",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4223",
+                           "localId" : "4393",
                            "name" : "conditions",
                            "elementType" : {
-                              "localId" : "4224",
+                              "localId" : "4394",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4225",
+                                 "localId" : "4395",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4226",
+                                    "localId" : "4396",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4227",
+                                       "localId" : "4397",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4228",
+                                    "localId" : "4398",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4229",
+                                       "localId" : "4399",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4230",
+                                    "localId" : "4400",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4231",
+                                       "localId" : "4401",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4232",
+                                    "localId" : "4402",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4233",
+                                       "localId" : "4403",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4234",
+                                    "localId" : "4404",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4235",
+                                       "localId" : "4405",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4236",
+                                          "localId" : "4406",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -18883,57 +19675,57 @@
                               }
                            }
                         }, {
-                           "localId" : "4237",
+                           "localId" : "4407",
                            "name" : "familyMemberHistory",
                            "elementType" : {
-                              "localId" : "4238",
+                              "localId" : "4408",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4239",
+                                 "localId" : "4409",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4240",
+                                    "localId" : "4410",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4241",
+                                       "localId" : "4411",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4242",
+                                          "localId" : "4412",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4243",
+                                       "localId" : "4413",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "4244",
+                                          "localId" : "4414",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4245",
+                                       "localId" : "4415",
                                        "name" : "onset",
                                        "elementType" : {
-                                          "localId" : "4246",
+                                          "localId" : "4416",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4247",
+                                       "localId" : "4417",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "4248",
+                                          "localId" : "4418",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4249",
+                                       "localId" : "4419",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "4250",
+                                          "localId" : "4420",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "4251",
+                                             "localId" : "4421",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -18943,54 +19735,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4252",
+                           "localId" : "4422",
                            "name" : "observations",
                            "elementType" : {
-                              "localId" : "4253",
+                              "localId" : "4423",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4254",
+                                 "localId" : "4424",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4255",
+                                    "localId" : "4425",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4256",
+                                       "localId" : "4426",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4257",
+                                    "localId" : "4427",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4258",
+                                       "localId" : "4428",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4259",
+                                    "localId" : "4429",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4260",
+                                       "localId" : "4430",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4261",
+                                    "localId" : "4431",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4262",
+                                       "localId" : "4432",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4263",
+                                    "localId" : "4433",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4264",
+                                       "localId" : "4434",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4265",
+                                          "localId" : "4435",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -18999,54 +19791,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4266",
+                           "localId" : "4436",
                            "name" : "procedures",
                            "elementType" : {
-                              "localId" : "4267",
+                              "localId" : "4437",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4268",
+                                 "localId" : "4438",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4269",
+                                    "localId" : "4439",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4270",
+                                       "localId" : "4440",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4271",
+                                    "localId" : "4441",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4272",
+                                       "localId" : "4442",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4273",
+                                    "localId" : "4443",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4274",
+                                       "localId" : "4444",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4275",
+                                    "localId" : "4445",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4276",
+                                       "localId" : "4446",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4277",
+                                    "localId" : "4447",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4278",
+                                       "localId" : "4448",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4279",
+                                          "localId" : "4449",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19055,66 +19847,74 @@
                               }
                            }
                         }, {
-                           "localId" : "4280",
+                           "localId" : "4450",
                            "name" : "diagnosticReports",
                            "elementType" : {
-                              "localId" : "4281",
+                              "localId" : "4451",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4282",
+                                 "localId" : "4452",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4283",
+                                    "localId" : "4453",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4284",
+                                       "localId" : "4454",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4285",
+                                    "localId" : "4455",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "4286",
+                                       "localId" : "4456",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4287",
+                                    "localId" : "4457",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4288",
+                                       "localId" : "4458",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "4459",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "4460",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4289",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "4461",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "4290",
+                                    "localId" : "4462",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4291",
+                                       "localId" : "4463",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4292",
+                                    "localId" : "4464",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4293",
+                                       "localId" : "4465",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4294",
+                                    "localId" : "4466",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4295",
+                                       "localId" : "4467",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4296",
+                                          "localId" : "4468",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19123,43 +19923,43 @@
                               }
                            }
                         }, {
-                           "localId" : "4297",
+                           "localId" : "4469",
                            "name" : "encounters",
                            "elementType" : {
-                              "localId" : "4298",
+                              "localId" : "4470",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4299",
+                                 "localId" : "4471",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4300",
+                                    "localId" : "4472",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4301",
+                                       "localId" : "4473",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4302",
+                                    "localId" : "4474",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4303",
+                                       "localId" : "4475",
                                        "name" : "{http://hl7.org/fhir}EncounterStatus",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4304",
+                                    "localId" : "4476",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4305",
+                                       "localId" : "4477",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4306",
+                                    "localId" : "4478",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4307",
+                                       "localId" : "4479",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -19167,54 +19967,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4308",
+                           "localId" : "4480",
                            "name" : "episodeOfCares",
                            "elementType" : {
-                              "localId" : "4309",
+                              "localId" : "4481",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4310",
+                                 "localId" : "4482",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4311",
+                                    "localId" : "4483",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4312",
+                                       "localId" : "4484",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4313",
+                                    "localId" : "4485",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4314",
+                                       "localId" : "4486",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4315",
+                                    "localId" : "4487",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4316",
+                                       "localId" : "4488",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4317",
+                                    "localId" : "4489",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4318",
+                                       "localId" : "4490",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4319",
+                                    "localId" : "4491",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4320",
+                                       "localId" : "4492",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4321",
+                                          "localId" : "4493",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19223,99 +20023,99 @@
                               }
                            }
                         }, {
-                           "localId" : "4322",
+                           "localId" : "4494",
                            "name" : "requests",
                            "elementType" : {
-                              "localId" : "4323",
+                              "localId" : "4495",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4324",
+                                 "localId" : "4496",
                                  "type" : "ChoiceTypeSpecifier",
                                  "type" : [ ],
                                  "choice" : [ {
-                                    "localId" : "4325",
+                                    "localId" : "4497",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4326",
+                                       "localId" : "4498",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4327",
+                                          "localId" : "4499",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4328",
+                                       "localId" : "4500",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4329",
+                                          "localId" : "4501",
                                           "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4330",
+                                       "localId" : "4502",
                                        "name" : "occurence",
                                        "elementType" : {
-                                          "localId" : "4331",
+                                          "localId" : "4503",
                                           "name" : "{http://hl7.org/fhir}dateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4332",
+                                       "localId" : "4504",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4333",
+                                          "localId" : "4505",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4334",
+                                       "localId" : "4506",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4335",
+                                          "localId" : "4507",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     } ]
                                  }, {
-                                    "localId" : "4336",
+                                    "localId" : "4508",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4337",
+                                       "localId" : "4509",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4338",
+                                          "localId" : "4510",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4339",
+                                       "localId" : "4511",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4340",
+                                          "localId" : "4512",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4341",
+                                       "localId" : "4513",
                                        "name" : "occurrence",
                                        "elementType" : {
-                                          "localId" : "4342",
+                                          "localId" : "4514",
                                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4343",
+                                       "localId" : "4515",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4344",
+                                          "localId" : "4516",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4345",
+                                       "localId" : "4517",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4346",
+                                          "localId" : "4518",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19569,57 +20369,57 @@
                      "locator" : "41:19-50:3",
                      "type" : "Tuple",
                      "resultTypeSpecifier" : {
-                        "localId" : "4074",
+                        "localId" : "4242",
                         "type" : "TupleTypeSpecifier",
                         "element" : [ {
-                           "localId" : "4075",
+                           "localId" : "4243",
                            "name" : "conditions",
                            "elementType" : {
-                              "localId" : "4076",
+                              "localId" : "4244",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4077",
+                                 "localId" : "4245",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4078",
+                                    "localId" : "4246",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4079",
+                                       "localId" : "4247",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4080",
+                                    "localId" : "4248",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4081",
+                                       "localId" : "4249",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4082",
+                                    "localId" : "4250",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4083",
+                                       "localId" : "4251",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4084",
+                                    "localId" : "4252",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4085",
+                                       "localId" : "4253",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4086",
+                                    "localId" : "4254",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4087",
+                                       "localId" : "4255",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4088",
+                                          "localId" : "4256",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19628,57 +20428,57 @@
                               }
                            }
                         }, {
-                           "localId" : "4089",
+                           "localId" : "4257",
                            "name" : "familyMemberHistory",
                            "elementType" : {
-                              "localId" : "4090",
+                              "localId" : "4258",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4091",
+                                 "localId" : "4259",
                                  "type" : "ListTypeSpecifier",
                                  "elementType" : {
-                                    "localId" : "4092",
+                                    "localId" : "4260",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4093",
+                                       "localId" : "4261",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4094",
+                                          "localId" : "4262",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4095",
+                                       "localId" : "4263",
                                        "name" : "value",
                                        "elementType" : {
-                                          "localId" : "4096",
+                                          "localId" : "4264",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4097",
+                                       "localId" : "4265",
                                        "name" : "onset",
                                        "elementType" : {
-                                          "localId" : "4098",
+                                          "localId" : "4266",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4099",
+                                       "localId" : "4267",
                                        "name" : "reference",
                                        "elementType" : {
-                                          "localId" : "4100",
+                                          "localId" : "4268",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4101",
+                                       "localId" : "4269",
                                        "name" : "edited",
                                        "elementType" : {
-                                          "localId" : "4102",
+                                          "localId" : "4270",
                                           "type" : "ListTypeSpecifier",
                                           "elementType" : {
-                                             "localId" : "4103",
+                                             "localId" : "4271",
                                              "name" : "{http://hl7.org/fhir}Extension",
                                              "type" : "NamedTypeSpecifier"
                                           }
@@ -19688,54 +20488,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4104",
+                           "localId" : "4272",
                            "name" : "observations",
                            "elementType" : {
-                              "localId" : "4105",
+                              "localId" : "4273",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4106",
+                                 "localId" : "4274",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4107",
+                                    "localId" : "4275",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4108",
+                                       "localId" : "4276",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4109",
+                                    "localId" : "4277",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4110",
+                                       "localId" : "4278",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4111",
+                                    "localId" : "4279",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4112",
+                                       "localId" : "4280",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4113",
+                                    "localId" : "4281",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4114",
+                                       "localId" : "4282",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4115",
+                                    "localId" : "4283",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4116",
+                                       "localId" : "4284",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4117",
+                                          "localId" : "4285",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19744,54 +20544,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4118",
+                           "localId" : "4286",
                            "name" : "procedures",
                            "elementType" : {
-                              "localId" : "4119",
+                              "localId" : "4287",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4120",
+                                 "localId" : "4288",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4121",
+                                    "localId" : "4289",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4122",
+                                       "localId" : "4290",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4123",
+                                    "localId" : "4291",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4124",
+                                       "localId" : "4292",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4125",
+                                    "localId" : "4293",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4126",
+                                       "localId" : "4294",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4127",
+                                    "localId" : "4295",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4128",
+                                       "localId" : "4296",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4129",
+                                    "localId" : "4297",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4130",
+                                       "localId" : "4298",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4131",
+                                          "localId" : "4299",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19800,66 +20600,74 @@
                               }
                            }
                         }, {
-                           "localId" : "4132",
+                           "localId" : "4300",
                            "name" : "diagnosticReports",
                            "elementType" : {
-                              "localId" : "4133",
+                              "localId" : "4301",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4134",
+                                 "localId" : "4302",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4135",
+                                    "localId" : "4303",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4136",
+                                       "localId" : "4304",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4137",
+                                    "localId" : "4305",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "4138",
+                                       "localId" : "4306",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4139",
+                                    "localId" : "4307",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4140",
+                                       "localId" : "4308",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "4309",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "4310",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4141",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "4311",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "4142",
+                                    "localId" : "4312",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4143",
+                                       "localId" : "4313",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4144",
+                                    "localId" : "4314",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4145",
+                                       "localId" : "4315",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4146",
+                                    "localId" : "4316",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4147",
+                                       "localId" : "4317",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4148",
+                                          "localId" : "4318",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19868,43 +20676,43 @@
                               }
                            }
                         }, {
-                           "localId" : "4149",
+                           "localId" : "4319",
                            "name" : "encounters",
                            "elementType" : {
-                              "localId" : "4150",
+                              "localId" : "4320",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4151",
+                                 "localId" : "4321",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4152",
+                                    "localId" : "4322",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4153",
+                                       "localId" : "4323",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4154",
+                                    "localId" : "4324",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4155",
+                                       "localId" : "4325",
                                        "name" : "{http://hl7.org/fhir}EncounterStatus",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4156",
+                                    "localId" : "4326",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4157",
+                                       "localId" : "4327",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4158",
+                                    "localId" : "4328",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4159",
+                                       "localId" : "4329",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -19912,54 +20720,54 @@
                               }
                            }
                         }, {
-                           "localId" : "4160",
+                           "localId" : "4330",
                            "name" : "episodeOfCares",
                            "elementType" : {
-                              "localId" : "4161",
+                              "localId" : "4331",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4162",
+                                 "localId" : "4332",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "4163",
+                                    "localId" : "4333",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "4164",
+                                       "localId" : "4334",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4165",
+                                    "localId" : "4335",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "4166",
+                                       "localId" : "4336",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4167",
+                                    "localId" : "4337",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "4168",
+                                       "localId" : "4338",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4169",
+                                    "localId" : "4339",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "4170",
+                                       "localId" : "4340",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "4171",
+                                    "localId" : "4341",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "4172",
+                                       "localId" : "4342",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "4173",
+                                          "localId" : "4343",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -19968,99 +20776,99 @@
                               }
                            }
                         }, {
-                           "localId" : "4174",
+                           "localId" : "4344",
                            "name" : "requests",
                            "elementType" : {
-                              "localId" : "4175",
+                              "localId" : "4345",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4176",
+                                 "localId" : "4346",
                                  "type" : "ChoiceTypeSpecifier",
                                  "type" : [ ],
                                  "choice" : [ {
-                                    "localId" : "4177",
+                                    "localId" : "4347",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4178",
+                                       "localId" : "4348",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4179",
+                                          "localId" : "4349",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4180",
+                                       "localId" : "4350",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4181",
+                                          "localId" : "4351",
                                           "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4182",
+                                       "localId" : "4352",
                                        "name" : "occurence",
                                        "elementType" : {
-                                          "localId" : "4183",
+                                          "localId" : "4353",
                                           "name" : "{http://hl7.org/fhir}dateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4184",
+                                       "localId" : "4354",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4185",
+                                          "localId" : "4355",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4186",
+                                       "localId" : "4356",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4187",
+                                          "localId" : "4357",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     } ]
                                  }, {
-                                    "localId" : "4188",
+                                    "localId" : "4358",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4189",
+                                       "localId" : "4359",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4190",
+                                          "localId" : "4360",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4191",
+                                       "localId" : "4361",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4192",
+                                          "localId" : "4362",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4193",
+                                       "localId" : "4363",
                                        "name" : "occurrence",
                                        "elementType" : {
-                                          "localId" : "4194",
+                                          "localId" : "4364",
                                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4195",
+                                       "localId" : "4365",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4196",
+                                          "localId" : "4366",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4197",
+                                       "localId" : "4367",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4198",
+                                          "localId" : "4368",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -20321,68 +21129,76 @@
                      }, {
                         "name" : "diagnosticReports",
                         "value" : {
-                           "localId" : "3228",
+                           "localId" : "3394",
                            "locator" : "46:24-46:47",
                            "name" : "DiagnosticReportsSummary",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3229",
+                              "localId" : "3395",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3230",
+                                 "localId" : "3396",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "3231",
+                                    "localId" : "3397",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "3232",
+                                       "localId" : "3398",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3233",
+                                    "localId" : "3399",
                                     "name" : "longName",
                                     "elementType" : {
-                                       "localId" : "3234",
+                                       "localId" : "3400",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3235",
+                                    "localId" : "3401",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "3236",
+                                       "localId" : "3402",
+                                       "name" : "{http://hl7.org/fhir}string",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }, {
+                                    "localId" : "3403",
+                                    "name" : "longValue",
+                                    "elementType" : {
+                                       "localId" : "3404",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3237",
-                                          "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                          "localId" : "3405",
+                                          "name" : "{http://hl7.org/fhir}string",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }
                                  }, {
-                                    "localId" : "3238",
+                                    "localId" : "3406",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "3239",
+                                       "localId" : "3407",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3240",
+                                    "localId" : "3408",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "3241",
+                                       "localId" : "3409",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3242",
+                                    "localId" : "3410",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "3243",
+                                       "localId" : "3411",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3244",
+                                          "localId" : "3412",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -20394,45 +21210,45 @@
                      }, {
                         "name" : "encounters",
                         "value" : {
-                           "localId" : "3357",
+                           "localId" : "3525",
                            "locator" : "47:17-47:42",
                            "name" : "PertinentEncountersSummary",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3358",
+                              "localId" : "3526",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3359",
+                                 "localId" : "3527",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "3360",
+                                    "localId" : "3528",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "3361",
+                                       "localId" : "3529",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3362",
+                                    "localId" : "3530",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "3363",
+                                       "localId" : "3531",
                                        "name" : "{http://hl7.org/fhir}EncounterStatus",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3364",
+                                    "localId" : "3532",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "3365",
+                                       "localId" : "3533",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3366",
+                                    "localId" : "3534",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "3367",
+                                       "localId" : "3535",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
@@ -20443,56 +21259,56 @@
                      }, {
                         "name" : "episodeOfCares",
                         "value" : {
-                           "localId" : "3550",
+                           "localId" : "3718",
                            "locator" : "48:21-48:50",
                            "name" : "PertinentEpisodesOfCareSummary",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "3551",
+                              "localId" : "3719",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "3552",
+                                 "localId" : "3720",
                                  "type" : "TupleTypeSpecifier",
                                  "element" : [ {
-                                    "localId" : "3553",
+                                    "localId" : "3721",
                                     "name" : "name",
                                     "elementType" : {
-                                       "localId" : "3554",
+                                       "localId" : "3722",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3555",
+                                    "localId" : "3723",
                                     "name" : "value",
                                     "elementType" : {
-                                       "localId" : "3556",
+                                       "localId" : "3724",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3557",
+                                    "localId" : "3725",
                                     "name" : "date",
                                     "elementType" : {
-                                       "localId" : "3558",
+                                       "localId" : "3726",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3559",
+                                    "localId" : "3727",
                                     "name" : "reference",
                                     "elementType" : {
-                                       "localId" : "3560",
+                                       "localId" : "3728",
                                        "name" : "{urn:hl7-org:elm-types:r1}String",
                                        "type" : "NamedTypeSpecifier"
                                     }
                                  }, {
-                                    "localId" : "3561",
+                                    "localId" : "3729",
                                     "name" : "edited",
                                     "elementType" : {
-                                       "localId" : "3562",
+                                       "localId" : "3730",
                                        "type" : "ListTypeSpecifier",
                                        "elementType" : {
-                                          "localId" : "3563",
+                                          "localId" : "3731",
                                           "name" : "{http://hl7.org/fhir}Extension",
                                           "type" : "NamedTypeSpecifier"
                                        }
@@ -20504,101 +21320,101 @@
                      }, {
                         "name" : "requests",
                         "value" : {
-                           "localId" : "4049",
+                           "localId" : "4217",
                            "locator" : "49:15-49:38",
                            "name" : "PertinentRequestsSummary",
                            "type" : "ExpressionRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "4050",
+                              "localId" : "4218",
                               "type" : "ListTypeSpecifier",
                               "elementType" : {
-                                 "localId" : "4051",
+                                 "localId" : "4219",
                                  "type" : "ChoiceTypeSpecifier",
                                  "type" : [ ],
                                  "choice" : [ {
-                                    "localId" : "4052",
+                                    "localId" : "4220",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4053",
+                                       "localId" : "4221",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4054",
+                                          "localId" : "4222",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4055",
+                                       "localId" : "4223",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4056",
+                                          "localId" : "4224",
                                           "name" : "{http://hl7.org/fhir}ServiceRequestIntent",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4057",
+                                       "localId" : "4225",
                                        "name" : "occurence",
                                        "elementType" : {
-                                          "localId" : "4058",
+                                          "localId" : "4226",
                                           "name" : "{http://hl7.org/fhir}dateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4059",
+                                       "localId" : "4227",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4060",
+                                          "localId" : "4228",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4061",
+                                       "localId" : "4229",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4062",
+                                          "localId" : "4230",
                                           "name" : "{urn:hl7-org:elm-types:r1}Any",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     } ]
                                  }, {
-                                    "localId" : "4063",
+                                    "localId" : "4231",
                                     "type" : "TupleTypeSpecifier",
                                     "element" : [ {
-                                       "localId" : "4064",
+                                       "localId" : "4232",
                                        "name" : "name",
                                        "elementType" : {
-                                          "localId" : "4065",
+                                          "localId" : "4233",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4066",
+                                       "localId" : "4234",
                                        "name" : "intent",
                                        "elementType" : {
-                                          "localId" : "4067",
+                                          "localId" : "4235",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4068",
+                                       "localId" : "4236",
                                        "name" : "occurrence",
                                        "elementType" : {
-                                          "localId" : "4069",
+                                          "localId" : "4237",
                                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4070",
+                                       "localId" : "4238",
                                        "name" : "flag",
                                        "elementType" : {
-                                          "localId" : "4071",
+                                          "localId" : "4239",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }
                                     }, {
-                                       "localId" : "4072",
+                                       "localId" : "4240",
                                        "name" : "plannedRepeat",
                                        "elementType" : {
-                                          "localId" : "4073",
+                                          "localId" : "4241",
                                           "name" : "{urn:hl7-org:elm-types:r1}String",
                                           "type" : "NamedTypeSpecifier"
                                        }

--- a/src/test/fhir/bundles/patients/SallySimpson.json
+++ b/src/test/fhir/bundles/patients/SallySimpson.json
@@ -198,7 +198,7 @@
           ]
         },
         "valueBoolean": true,
-        "effectiveDateTime": "2024-12-10T00:00:00.000Z"
+        "effectiveDateTime": "2025-03-20T00:00:00.000Z"
       }
     }
   ]

--- a/src/test/fhir/test.config.js
+++ b/src/test/fhir/test.config.js
@@ -84,7 +84,7 @@ export const config = {
               display: 'Condition'
             },
             {
-              key: 'state',
+              key: 'value',
               display: 'Status'
             },
             {

--- a/src/test/fhir/test.config.js
+++ b/src/test/fhir/test.config.js
@@ -58,10 +58,10 @@ export const config = {
             {
               key: 'value',
               display: 'Result',
-              detailKey: 'longValue'
+              detailKey: 'value'
             },            
             {
-              key: 'age',
+              key: 'onset',
               display: 'Age at Diagnosis'
             },
             {


### PR DESCRIPTION
Add fixes from crcsm-cds history-bug branch and patch to PertinentHistory.cql to get diagnostic report results to show.